### PR TITLE
fix(interactions): handle empty options

### DIFF
--- a/packages/http-framework/src/lib/interactions/resolvers/InteractionOptions.ts
+++ b/packages/http-framework/src/lib/interactions/resolvers/InteractionOptions.ts
@@ -59,22 +59,24 @@ export type AutocompleteInteractionArguments<T extends NonNullObject> = Interact
 };
 
 export function extractTopLevelOptions(options: readonly APIApplicationCommandInteractionDataOption[]): ExtractedOptions {
-	const [firstOption] = options;
-	if (firstOption.type === ApplicationCommandOptionType.SubcommandGroup) {
-		const subCommand = firstOption.options[0];
-		return {
-			subCommandGroup: firstOption,
-			subCommand,
-			options: subCommand.options ?? []
-		};
-	}
+	if (options.length) {
+		const [firstOption] = options;
+		if (firstOption.type === ApplicationCommandOptionType.SubcommandGroup) {
+			const subCommand = firstOption.options[0];
+			return {
+				subCommandGroup: firstOption,
+				subCommand,
+				options: subCommand.options ?? []
+			};
+		}
 
-	if (firstOption.type === ApplicationCommandOptionType.Subcommand) {
-		return {
-			subCommandGroup: null,
-			subCommand: firstOption,
-			options: firstOption.options ?? []
-		};
+		if (firstOption.type === ApplicationCommandOptionType.Subcommand) {
+			return {
+				subCommandGroup: null,
+				subCommand: firstOption,
+				options: firstOption.options ?? []
+			};
+		}
 	}
 
 	return {

--- a/packages/http-framework/src/lib/structures/Command.ts
+++ b/packages/http-framework/src/lib/structures/Command.ts
@@ -111,7 +111,7 @@ export abstract class Command extends Piece {
 	}
 
 	protected routeChatInputInteraction(data: APIChatInputApplicationCommandInteractionData): string | null {
-		if (!data.options) return 'chatInputRun';
+		if (!data.options?.length) return 'chatInputRun';
 
 		const [firstOption] = data.options;
 		if (firstOption.type === ApplicationCommandOptionType.Subcommand) {

--- a/packages/http-framework/tests/resolvers/InteractionOptions.test.ts
+++ b/packages/http-framework/tests/resolvers/InteractionOptions.test.ts
@@ -8,6 +8,16 @@ import { extractTopLevelOptions, transformAutocompleteInteraction, transformInte
 
 describe('InteractionOptions', () => {
 	describe('transformInteraction', () => {
+		test('GIVEN no options THEN returns empty data', () => {
+			const options: APIApplicationCommandInteractionDataBasicOption[] = [];
+			const given = transformInteraction({}, options);
+
+			expect(given).toStrictEqual({
+				subCommandGroup: null,
+				subCommand: null
+			});
+		});
+
 		test('GIVEN top-level options THEN returns all data correctly', () => {
 			const options: APIApplicationCommandInteractionDataBasicOption[] = [
 				{ type: ApplicationCommandOptionType.String, name: 'name', value: 'Hello World' },
@@ -70,6 +80,17 @@ describe('InteractionOptions', () => {
 	});
 
 	describe('transformAutocompleteInteraction', () => {
+		test('GIVEN no options THEN returns empty data', () => {
+			const options: APIApplicationCommandInteractionDataBasicOption[] = [];
+			const given = transformAutocompleteInteraction({}, options);
+
+			expect(given).toStrictEqual({
+				subCommandGroup: null,
+				subCommand: null,
+				focused: null
+			});
+		});
+
 		test('GIVEN top-level options THEN returns all data correctly', () => {
 			const options: APIApplicationCommandInteractionDataBasicOption[] = [
 				{ type: ApplicationCommandOptionType.String, name: 'name', value: 'Hello World', focused: true },
@@ -135,6 +156,17 @@ describe('InteractionOptions', () => {
 	});
 
 	describe('extractTopLevelOptions', () => {
+		test('GIVEN no options THEN returns empty data', () => {
+			const options: APIApplicationCommandInteractionDataBasicOption[] = [];
+			const given = extractTopLevelOptions(options);
+
+			expect(given).toStrictEqual({
+				subCommandGroup: null,
+				subCommand: null,
+				options
+			});
+		});
+
 		test('GIVEN top-level options THEN returns SCG and SC null', () => {
 			const options: APIApplicationCommandInteractionDataBasicOption[] = [
 				{ type: ApplicationCommandOptionType.String, name: 'name', value: 'Hello World' },


### PR DESCRIPTION
Fixes the interaction argument parser for commands that have no options
