### PR TITLE
fix(env-utilities): do not assign debug to false

### DIFF
--- a/packages/env-utilities/src/lib/setup.ts
+++ b/packages/env-utilities/src/lib/setup.ts
@@ -1,7 +1,7 @@
 import type { DotenvConfigOutput } from 'dotenv';
 import { config, type DotenvCraOptions } from 'dotenv-cra';
 import { fileURLToPath } from 'node:url';
-import { envParseBoolean } from './utils';
+import { envIsDefined, envParseBoolean } from './utils';
 
 export function setup(pathOrOptions?: string | URL | EnvSetupOptions): DotenvConfigOutput {
 	// Unless explicitly defined, set NODE_ENV as development:
@@ -24,7 +24,7 @@ export function setup(pathOrOptions?: string | URL | EnvSetupOptions): DotenvCon
 	}
 
 	return config({
-		debug: envParseBoolean('DOTENV_DEBUG', false),
+		debug: envIsDefined('DOTENV_DEBUG') ? envParseBoolean('DOTENV_DEBUG') : undefined,
 		encoding: process.env.DOTENV_ENCODING,
 		env: process.env.DOTENV_ENV,
 		path: process.env.DOTENV_PATH,

--- a/packages/env-utilities/src/lib/utils.ts
+++ b/packages/env-utilities/src/lib/utils.ts
@@ -1,6 +1,8 @@
 import type { Env, EnvAny, EnvBoolean, EnvInteger, EnvNumber, EnvString } from './types';
 
-export function envParseInteger(key: EnvInteger, defaultValue?: number): number {
+export function envParseInteger(key: EnvInteger, defaultValue: number | null): number | null;
+export function envParseInteger(key: EnvInteger, defaultValue?: number): number;
+export function envParseInteger(key: EnvInteger, defaultValue?: number | null): number | null {
 	const value = process.env[key];
 	if (!value) {
 		if (defaultValue === undefined) throw new ReferenceError(`[ENV] ${key} - The key must be an integer, but is empty or undefined.`);
@@ -12,7 +14,9 @@ export function envParseInteger(key: EnvInteger, defaultValue?: number): number 
 	throw new TypeError(`[ENV] ${key} - The key must be an integer, but received '${value}'.`);
 }
 
-export function envParseNumber(key: EnvNumber, defaultValue?: number): number {
+export function envParseNumber(key: EnvNumber, defaultValue: number | null): number | null;
+export function envParseNumber(key: EnvNumber, defaultValue?: number): number;
+export function envParseNumber(key: EnvNumber, defaultValue?: number | null): number | null {
 	const value = process.env[key];
 	if (!value) {
 		if (defaultValue === undefined) throw new ReferenceError(`[ENV] ${key} - The key must be a number, but is empty or undefined.`);
@@ -24,7 +28,9 @@ export function envParseNumber(key: EnvNumber, defaultValue?: number): number {
 	throw new TypeError(`[ENV] ${key} - The key must be a number, but received '${value}'.`);
 }
 
-export function envParseBoolean(key: EnvBoolean, defaultValue?: boolean): boolean {
+export function envParseBoolean(key: EnvBoolean, defaultValue: boolean | null): boolean | null;
+export function envParseBoolean(key: EnvBoolean, defaultValue?: boolean): boolean;
+export function envParseBoolean(key: EnvBoolean, defaultValue?: boolean | null): boolean | null {
 	const value = process.env[key];
 	if (!value) {
 		if (defaultValue === undefined) throw new ReferenceError(`[ENV] ${key} - The key must be a boolean, but is empty or undefined.`);
@@ -36,7 +42,9 @@ export function envParseBoolean(key: EnvBoolean, defaultValue?: boolean): boolea
 	throw new TypeError(`[ENV] ${key} - The key must be a boolean, but received '${value}'.`);
 }
 
-export function envParseString<K extends EnvString>(key: K, defaultValue?: Env[K]): Env[K] {
+export function envParseString<K extends EnvString>(key: K, defaultValue: Env[K] | null): Env[K] | null;
+export function envParseString<K extends EnvString>(key: K, defaultValue?: Env[K]): Env[K];
+export function envParseString<K extends EnvString>(key: K, defaultValue?: Env[K] | null): Env[K] | null {
 	const value = process.env[key];
 	if (!value) {
 		if (defaultValue === undefined) throw new ReferenceError(`[ENV] ${key} - The key must be a string, but is empty or undefined.`);
@@ -46,7 +54,9 @@ export function envParseString<K extends EnvString>(key: K, defaultValue?: Env[K
 	return value;
 }
 
-export function envParseArray(key: EnvString, defaultValue?: string[]): string[] {
+export function envParseArray(key: EnvString, defaultValue: string[] | null): string[] | null;
+export function envParseArray(key: EnvString, defaultValue?: string[]): string[];
+export function envParseArray(key: EnvString, defaultValue?: string[] | null): string[] | null {
 	const value = process.env[key];
 	if (!value) {
 		if (defaultValue === undefined) throw new ReferenceError(`[ENV] ${key} - The key must be an array, but is empty or undefined.`);


### PR DESCRIPTION
`dotenv`'s code is a hall of shame, and sets `debug` to `true` even if `options.debug` is false.
