### PR TITLE
feat(Logger): add package

### DIFF
--- a/.npm-deprecaterc.yml
+++ b/.npm-deprecaterc.yml
@@ -4,6 +4,7 @@ package:
   - '@skyra/http-framework'
   - '@skyra/http-framework-i18n'
   - '@skyra/i18next-backend'
+  - '@skyra/logger'
   - '@skyra/shared-http-pieces'
   # TODO: Fix name when package.json is created
   # - '@skyra/shared-gateway-pieces'

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 [![npm](https://img.shields.io/npm/v/@skyra/http-framework?color=crimson&logo=npm&style=flat-square&label=@skyra/http-framework)](https://www.npmjs.com/package/@skyra/http-framework)
 [![npm](https://img.shields.io/npm/v/@skyra/http-framework-i18n?color=crimson&logo=npm&style=flat-square&label=@skyra/http-framework-i18n)](https://www.npmjs.com/package/@skyra/http-framework-i18n)
 [![npm](https://img.shields.io/npm/v/@skyra/i18next-backend?color=crimson&logo=npm&style=flat-square&label=@skyra/i18next-backend)](https://www.npmjs.com/package/@skyra/i18next-backend)
+[![npm](https://img.shields.io/npm/v/@skyra/logger?color=crimson&logo=npm&style=flat-square&label=@skyra/logger)](https://www.npmjs.com/package/@skyra/logger)
 [![npm](https://img.shields.io/npm/v/@skyra/shared-gateway-pieces?color=crimson&logo=npm&style=flat-square&label=@skyra/shared-gateway-pieces)](https://www.npmjs.com/package/@skyra/shared-gateway-pieces)
 [![npm](https://img.shields.io/npm/v/@skyra/shared-http-pieces?color=crimson&logo=npm&style=flat-square&label=@skyra/shared-http-pieces)](https://www.npmjs.com/package/@skyra/shared-http-pieces)
 [![npm](https://img.shields.io/npm/v/@skyra/start-banner?color=crimson&logo=npm&style=flat-square&label=@skyra/start-banner)](https://www.npmjs.com/package/@skyra/start-banner)

--- a/packages/logger/.cliff-jumperrc.yml
+++ b/packages/logger/.cliff-jumperrc.yml
@@ -1,0 +1,3 @@
+name: logger
+org: skyra
+packagePath: packages/logger

--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -1,0 +1,19 @@
+# `@skyra/logger`
+
+A lightweight logger system with level support.
+
+## Usage
+
+```typescript
+import { Logger } from '@skyra/logger';
+
+const logger = new Logger();
+
+logger.info('Hello world');
+// [2022/08/04-13:28:58] INFO (19284): Hello World
+
+logger.info('Hello, %s', 'Skyra');
+// [2022/08/04-13:29:46] INFO (19284): Hello, Skyra
+```
+
+For ease of use, `@skyra/logger` re-exports all the functions from [`colorette`](https://www.npmjs.com/package/colorette).

--- a/packages/logger/cliff.toml
+++ b/packages/logger/cliff.toml
@@ -1,0 +1,63 @@
+[changelog]
+header = """
+# Changelog
+
+All notable changes to this project will be documented in this file.\n
+"""
+body = """
+{% if version %}\
+    # [{{ version | trim_start_matches(pat="v") }}]\
+    {% if previous %}\
+        {% if previous.version %}\
+            (https://github.com/skyra-project/archid-components/compare/{{ previous.version }}...{{ version }})\
+        {% else %}\
+            (https://github.com/skyra-project/archid-components/tree/{{ version }})\
+        {% endif %}\
+    {% endif %} \
+    - ({{ timestamp | date(format="%Y-%m-%d") }})
+{% else %}\
+    # [unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ## {{ group | upper_first }}
+    {% for commit in commits %}
+		- {% if commit.scope %}\
+			**{{commit.scope}}:** \
+		  {% endif %}\
+            {{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/skyra-project/archid-components/commit/{{ commit.id }}))\
+		{% if commit.breaking %}\
+			{% for breakingChange in commit.footers %}\
+				\n{% raw %}  {% endraw %}- 💥 **{{ breakingChange.token }}{{ breakingChange.separator }}** {{ breakingChange.value }}\
+			{% endfor %}\
+		{% endif %}\
+    {% endfor %}
+{% endfor %}\n
+"""
+trim = true
+footer = ""
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+commit_parsers = [
+    { message = "^feat", group = "🚀 Features"},
+    { message = "^fix", group = "🐛 Bug Fixes"},
+    { message = "^docs", group = "📝 Documentation"},
+    { message = "^perf", group = "🏃 Performance"},
+    { message = "^refactor", group = "🏠 Refactor"},
+    { message = "^typings", group = "⌨️ Typings"},
+    { message = "^types", group = "⌨️ Typings"},
+    { message = ".*deprecated", body = ".*deprecated", group = "🚨 Deprecation"},
+    { message = "^revert", skip = true},
+    { message = "^style", group = "🪞 Styling"},
+    { message = "^test", group = "🧪 Testing"},
+    { message = "^chore", skip = true},
+    { message = "^ci", skip = true},
+    { message = "^build", skip = true},
+    { body = ".*security", group = "🛡️ Security"},
+]
+filter_commits = true
+tag_pattern = "@skyra/logger@[0-9]*"
+ignore_tags = ""
+topo_order = false
+sort_commits = "newest"

--- a/packages/logger/jest.config.mjs
+++ b/packages/logger/jest.config.mjs
@@ -1,0 +1,15 @@
+/** @type {import('@jest/types').Config.InitialOptions} */
+const config = {
+	displayName: 'unit test',
+	preset: 'ts-jest',
+	testMatch: ['<rootDir>/tests/**/*.test.ts'],
+	collectCoverageFrom: ['<rootDir>/src/**/*.ts'],
+	setupFilesAfterEnv: ['jest-extended/all'],
+	globals: {
+		'ts-jest': {
+			tsconfig: '<rootDir>/tests/tsconfig.json'
+		}
+	}
+};
+
+export default config;

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,0 +1,60 @@
+{
+	"name": "@skyra/logger",
+	"version": "1.0.0",
+	"description": "A lightweight logger system with level support",
+	"author": "@skyra",
+	"license": "Apache-2.0",
+	"main": "dist/index.js",
+	"module": "dist/index.mjs",
+	"types": "dist/index.d.ts",
+	"exports": {
+		"import": "./dist/index.mjs",
+		"types": "./dist/index.d.ts"
+	},
+	"sideEffects": false,
+	"scripts": {
+		"test": "jest",
+		"build": "tsup",
+		"watch": "tsup --watch",
+		"lint": "eslint src --ext ts --fix -c ../../package.json",
+		"prepack": "yarn build",
+		"bump": "cliff-jumper",
+		"check-update": "cliff-jumper --dry-run"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/skyra-project/archid-components.git",
+		"directory": "packages/logger"
+	},
+	"files": [
+		"dist/**/*.mjs*",
+		"dist/**/*.d.ts"
+	],
+	"engines": {
+		"node": ">=16.9.0",
+		"npm": ">=8.0.0"
+	},
+	"keywords": [
+		"discord",
+		"api",
+		"http",
+		"skyra",
+		"typescript",
+		"ts",
+		"yarn"
+	],
+	"bugs": {
+		"url": "https://github.com/skyra-project/archid-components/issues"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"dependencies": {
+		"colorette": "2.0.19"
+	},
+	"devDependencies": {
+		"@favware/cliff-jumper": "^1.8.6",
+		"tsup": "^6.2.1",
+		"typescript": "^4.7.4"
+	}
+}

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,0 +1,2 @@
+export * from 'colorette';
+export * from './lib/Logger';

--- a/packages/logger/src/lib/Logger.ts
+++ b/packages/logger/src/lib/Logger.ts
@@ -1,0 +1,114 @@
+import { blue, gray, magenta, red, redBright, yellow, type Color } from 'colorette';
+import { format, inspect } from 'node:util';
+
+export class Logger {
+	/**
+	 * The depth of the inspect.
+	 */
+	public readonly level: Logger.Level;
+
+	/**
+	 * The inspect depth when logging objects.
+	 */
+	public readonly depth: number;
+
+	/**
+	 * The context for each logging level.
+	 */
+	public readonly levels: Readonly<Record<Logger.Level, Readonly<Logger.LevelContext>>>;
+
+	public constructor(options: Logger.Options = {}) {
+		this.level = options.level ?? Logger.Level.Info;
+		this.depth = options.depth ?? 0;
+		this.levels = {
+			[Logger.Level.Trace]: { color: gray, method: 'trace', name: 'TRACE' },
+			[Logger.Level.Debug]: { color: magenta, method: 'debug', name: 'DEBUG' },
+			[Logger.Level.Info]: { color: blue, method: 'info', name: 'INFO' },
+			[Logger.Level.Warn]: { color: yellow, method: 'warn', name: 'WARN' },
+			[Logger.Level.Error]: { color: red, method: 'error', name: 'ERROR' },
+			[Logger.Level.Fatal]: { color: redBright, method: 'error', name: 'FATAL' },
+			...options.levels
+		};
+	}
+
+	public enabled(level: Logger.Level): boolean {
+		return level >= this.level;
+	}
+
+	public disabled(level: Logger.Level): boolean {
+		return level < this.level;
+	}
+
+	public trace(value: unknown, ...args: readonly unknown[]): void {
+		if (this.enabled(Logger.Level.Trace)) this.write(this.levels[Logger.Level.Trace], value, args);
+	}
+
+	public debug(value: unknown, ...args: readonly unknown[]): void {
+		if (this.enabled(Logger.Level.Debug)) this.write(this.levels[Logger.Level.Debug], value, args);
+	}
+
+	public info(value: unknown, ...args: readonly unknown[]): void {
+		if (this.enabled(Logger.Level.Info)) this.write(this.levels[Logger.Level.Info], value, args);
+	}
+
+	public warn(value: unknown, ...args: readonly unknown[]): void {
+		if (this.enabled(Logger.Level.Warn)) this.write(this.levels[Logger.Level.Warn], value, args);
+	}
+
+	public error(value: unknown, ...args: readonly unknown[]): void {
+		if (this.enabled(Logger.Level.Error)) this.write(this.levels[Logger.Level.Error], value, args);
+	}
+
+	public fatal(value: unknown, ...args: readonly unknown[]): void {
+		if (this.enabled(Logger.Level.Fatal)) this.write(this.levels[Logger.Level.Fatal], value, args);
+	}
+
+	private write(context: Logger.LevelContext, value: unknown, args: readonly unknown[]): void {
+		const header = `[${context.color(this.time)}] ${context.color(context.name)} (${process.pid}): `;
+		const formatted = typeof value === 'string' ? format(value, ...args) : inspect(value, { colors: true });
+
+		console[context.method](`${header}${formatted.replaceAll('\n', `\n${header}`)}`);
+	}
+
+	private get time() {
+		const date = new Date();
+		const YYYY = String(date.getUTCFullYear());
+		const MM = String(date.getUTCMonth() + 1).padStart(2, '0');
+		const DD = String(date.getUTCDate()).padStart(2, '0');
+
+		const hh = String(date.getUTCHours()).padStart(2, '0');
+		const mm = String(date.getUTCMinutes()).padStart(2, '0');
+		const ss = String(date.getUTCSeconds()).padStart(2, '0');
+
+		return `${YYYY}/${MM}/${DD}-${hh}:${mm}:${ss}`;
+	}
+}
+
+export namespace Logger {
+	export interface Options {
+		level?: Level;
+		depth?: number;
+		levels?: Partial<Record<Level, LevelContext>>;
+	}
+
+	export const enum Level {
+		Trace,
+		Debug,
+		Info,
+		Warn,
+		Error,
+		Fatal
+	}
+
+	export interface LevelContext {
+		color: Color;
+		name: string;
+		method: Method;
+	}
+
+	export interface Format {
+		(value: string): string;
+	}
+
+	export type Method = 'debug' | 'error' | 'info' | 'trace' | 'warn';
+}

--- a/packages/logger/src/tsconfig.json
+++ b/packages/logger/src/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "./",
+		"outDir": "../dist",
+		"tsBuildInfoFile": "../dist/.tsbuildinfo"
+	},
+	"include": ["."]
+}

--- a/packages/logger/tests/lib/Logger.test.ts
+++ b/packages/logger/tests/lib/Logger.test.ts
@@ -1,0 +1,161 @@
+import { blue, gray, magenta, red, redBright, yellow } from 'colorette';
+import { Logger } from '../../src';
+
+describe('Logger', () => {
+	describe('constructor', () => {
+		test('GIVEN no options THEN assigns correct defaults', () => {
+			const logger = new Logger();
+
+			expect(logger.depth).toBe(0);
+			expect(logger.level).toBe(Logger.Level.Info);
+			expect(logger.levels).toEqual({
+				[Logger.Level.Trace]: { color: gray, method: 'trace', name: 'TRACE' },
+				[Logger.Level.Debug]: { color: magenta, method: 'debug', name: 'DEBUG' },
+				[Logger.Level.Info]: { color: blue, method: 'info', name: 'INFO' },
+				[Logger.Level.Warn]: { color: yellow, method: 'warn', name: 'WARN' },
+				[Logger.Level.Error]: { color: red, method: 'error', name: 'ERROR' },
+				[Logger.Level.Fatal]: { color: redBright, method: 'error', name: 'FATAL' }
+			});
+		});
+
+		test('GIVEN empty object THEN assigns correct defaults', () => {
+			expect(new Logger({})).toEqual(new Logger());
+		});
+	});
+
+	describe('enabled', () => {
+		test('GIVEN level trace THEN all levels return true', () => {
+			const logger = new Logger({ level: Logger.Level.Trace });
+
+			expect(logger.enabled(Logger.Level.Trace)).toBe(true);
+			expect(logger.enabled(Logger.Level.Debug)).toBe(true);
+			expect(logger.enabled(Logger.Level.Info)).toBe(true);
+			expect(logger.enabled(Logger.Level.Warn)).toBe(true);
+			expect(logger.enabled(Logger.Level.Error)).toBe(true);
+			expect(logger.enabled(Logger.Level.Fatal)).toBe(true);
+		});
+
+		test('GIVEN level debug THEN trace level returns false', () => {
+			const logger = new Logger({ level: Logger.Level.Debug });
+
+			expect(logger.enabled(Logger.Level.Trace)).toBe(false);
+			expect(logger.enabled(Logger.Level.Debug)).toBe(true);
+			expect(logger.enabled(Logger.Level.Info)).toBe(true);
+			expect(logger.enabled(Logger.Level.Warn)).toBe(true);
+			expect(logger.enabled(Logger.Level.Error)).toBe(true);
+			expect(logger.enabled(Logger.Level.Fatal)).toBe(true);
+		});
+
+		test('GIVEN level info THEN trace and debug levels return false', () => {
+			const logger = new Logger({ level: Logger.Level.Info });
+
+			expect(logger.enabled(Logger.Level.Trace)).toBe(false);
+			expect(logger.enabled(Logger.Level.Debug)).toBe(false);
+			expect(logger.enabled(Logger.Level.Info)).toBe(true);
+			expect(logger.enabled(Logger.Level.Warn)).toBe(true);
+			expect(logger.enabled(Logger.Level.Error)).toBe(true);
+			expect(logger.enabled(Logger.Level.Fatal)).toBe(true);
+		});
+
+		test('GIVEN level warn THEN trace, debug, and info levels return false', () => {
+			const logger = new Logger({ level: Logger.Level.Warn });
+
+			expect(logger.enabled(Logger.Level.Trace)).toBe(false);
+			expect(logger.enabled(Logger.Level.Debug)).toBe(false);
+			expect(logger.enabled(Logger.Level.Info)).toBe(false);
+			expect(logger.enabled(Logger.Level.Warn)).toBe(true);
+			expect(logger.enabled(Logger.Level.Error)).toBe(true);
+			expect(logger.enabled(Logger.Level.Fatal)).toBe(true);
+		});
+
+		test('GIVEN level error THEN only error and fatal return true', () => {
+			const logger = new Logger({ level: Logger.Level.Error });
+
+			expect(logger.enabled(Logger.Level.Trace)).toBe(false);
+			expect(logger.enabled(Logger.Level.Debug)).toBe(false);
+			expect(logger.enabled(Logger.Level.Info)).toBe(false);
+			expect(logger.enabled(Logger.Level.Warn)).toBe(false);
+			expect(logger.enabled(Logger.Level.Error)).toBe(true);
+			expect(logger.enabled(Logger.Level.Fatal)).toBe(true);
+		});
+
+		test('GIVEN level fatal THEN only fatal returns true', () => {
+			const logger = new Logger({ level: Logger.Level.Fatal });
+
+			expect(logger.enabled(Logger.Level.Trace)).toBe(false);
+			expect(logger.enabled(Logger.Level.Debug)).toBe(false);
+			expect(logger.enabled(Logger.Level.Info)).toBe(false);
+			expect(logger.enabled(Logger.Level.Warn)).toBe(false);
+			expect(logger.enabled(Logger.Level.Error)).toBe(false);
+			expect(logger.enabled(Logger.Level.Fatal)).toBe(true);
+		});
+	});
+
+	describe('disabled', () => {
+		test('GIVEN level trace THEN all levels return false', () => {
+			const logger = new Logger({ level: Logger.Level.Trace });
+
+			expect(logger.disabled(Logger.Level.Trace)).toBe(false);
+			expect(logger.disabled(Logger.Level.Debug)).toBe(false);
+			expect(logger.disabled(Logger.Level.Info)).toBe(false);
+			expect(logger.disabled(Logger.Level.Warn)).toBe(false);
+			expect(logger.disabled(Logger.Level.Error)).toBe(false);
+			expect(logger.disabled(Logger.Level.Fatal)).toBe(false);
+		});
+
+		test('GIVEN level debug THEN trace level returns true', () => {
+			const logger = new Logger({ level: Logger.Level.Debug });
+
+			expect(logger.disabled(Logger.Level.Trace)).toBe(true);
+			expect(logger.disabled(Logger.Level.Debug)).toBe(false);
+			expect(logger.disabled(Logger.Level.Info)).toBe(false);
+			expect(logger.disabled(Logger.Level.Warn)).toBe(false);
+			expect(logger.disabled(Logger.Level.Error)).toBe(false);
+			expect(logger.disabled(Logger.Level.Fatal)).toBe(false);
+		});
+
+		test('GIVEN level info THEN trace and debug levels return true', () => {
+			const logger = new Logger({ level: Logger.Level.Info });
+
+			expect(logger.disabled(Logger.Level.Trace)).toBe(true);
+			expect(logger.disabled(Logger.Level.Debug)).toBe(true);
+			expect(logger.disabled(Logger.Level.Info)).toBe(false);
+			expect(logger.disabled(Logger.Level.Warn)).toBe(false);
+			expect(logger.disabled(Logger.Level.Error)).toBe(false);
+			expect(logger.disabled(Logger.Level.Fatal)).toBe(false);
+		});
+
+		test('GIVEN level warn THEN trace, debug, and info levels return true', () => {
+			const logger = new Logger({ level: Logger.Level.Warn });
+
+			expect(logger.disabled(Logger.Level.Trace)).toBe(true);
+			expect(logger.disabled(Logger.Level.Debug)).toBe(true);
+			expect(logger.disabled(Logger.Level.Info)).toBe(true);
+			expect(logger.disabled(Logger.Level.Warn)).toBe(false);
+			expect(logger.disabled(Logger.Level.Error)).toBe(false);
+			expect(logger.disabled(Logger.Level.Fatal)).toBe(false);
+		});
+
+		test('GIVEN level error THEN only error and fatal return false', () => {
+			const logger = new Logger({ level: Logger.Level.Error });
+
+			expect(logger.disabled(Logger.Level.Trace)).toBe(true);
+			expect(logger.disabled(Logger.Level.Debug)).toBe(true);
+			expect(logger.disabled(Logger.Level.Info)).toBe(true);
+			expect(logger.disabled(Logger.Level.Warn)).toBe(true);
+			expect(logger.disabled(Logger.Level.Error)).toBe(false);
+			expect(logger.disabled(Logger.Level.Fatal)).toBe(false);
+		});
+
+		test('GIVEN level fatal THEN only fatal returns false', () => {
+			const logger = new Logger({ level: Logger.Level.Fatal });
+
+			expect(logger.disabled(Logger.Level.Trace)).toBe(true);
+			expect(logger.disabled(Logger.Level.Debug)).toBe(true);
+			expect(logger.disabled(Logger.Level.Info)).toBe(true);
+			expect(logger.disabled(Logger.Level.Warn)).toBe(true);
+			expect(logger.disabled(Logger.Level.Error)).toBe(true);
+			expect(logger.disabled(Logger.Level.Fatal)).toBe(false);
+		});
+	});
+});

--- a/packages/logger/tests/tsconfig.json
+++ b/packages/logger/tests/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "../../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": ".",
+		"outDir": "../test-dist",
+		"tsBuildInfoFile": "../test-dist/.tsbuildinfo"
+	},
+	"include": [".", "../src/**/*"],
+	"references": [{ "path": "../src" }]
+}

--- a/packages/logger/tsconfig.eslint.json
+++ b/packages/logger/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"include": ["src", "tsup.config.ts"]
+}

--- a/packages/logger/tsup.config.ts
+++ b/packages/logger/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../scripts/tsup.config';
+
+export default createTsupConfig({ format: ['esm'] });

--- a/scripts/clean.mjs
+++ b/scripts/clean.mjs
@@ -10,6 +10,7 @@ const paths = [
 	new URL('http-framework/dist/', packagesDir),
 	new URL('http-framework-i18n/dist/', packagesDir),
 	new URL('i18next-backend/dist/', packagesDir),
+	new URL('logger/dist/', packagesDir),
 	new URL('shared-gateway-pieces/dist/', packagesDir),
 	new URL('shared-http-pieces/dist/', packagesDir),
 	new URL('start-banner/dist/', packagesDir),
@@ -19,6 +20,7 @@ const paths = [
 	new URL('http-framework/.turbo/', packagesDir),
 	new URL('http-framework-i18n/.turbo/', packagesDir),
 	new URL('i18next-backend/.turbo/', packagesDir),
+	new URL('logger/.turbo/', packagesDir),
 	new URL('shared-gateway-pieces/.turbo/', packagesDir),
 	new URL('shared-http-pieces/.turbo/', packagesDir),
 	new URL('start-banner/.turbo/', packagesDir)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1282,6 +1282,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@skyra/logger@workspace:packages/logger":
+  version: 0.0.0-use.local
+  resolution: "@skyra/logger@workspace:packages/logger"
+  dependencies:
+    "@favware/cliff-jumper": ^1.8.6
+    colorette: 2.0.19
+    tsup: ^6.2.1
+    typescript: ^4.7.4
+  languageName: unknown
+  linkType: soft
+
 "@skyra/shared-http-pieces@workspace:packages/shared-http-pieces":
   version: 0.0.0-use.local
   resolution: "@skyra/shared-http-pieces@workspace:packages/shared-http-pieces"
@@ -2613,7 +2624,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"colorette@npm:^2.0.16, colorette@npm:^2.0.17, colorette@npm:^2.0.19":
+"colorette@npm:2.0.19, colorette@npm:^2.0.16, colorette@npm:^2.0.17, colorette@npm:^2.0.19":
   version: 2.0.19
   resolution: "colorette@npm:2.0.19"
   checksum: 888cf5493f781e5fcf54ce4d49e9d7d698f96ea2b2ef67906834bb319a392c667f9ec69f4a10e268d2946d13a9503d2d19b3abaaaf174e3451bfe91fb9d82427


### PR DESCRIPTION
This logger is based on Iriss's [logger](https://github.com/skyra-project/iriss/blob/aa2b53ec5a5312430434aa13295e0892d69d5089/src/lib/setup/logger.ts) and draws inspiration from [`@sapphire/plugin-logger`](https://www.npmjs.com/package/@sapphire/plugin-logger), however, it has several differences:

- It does not require `@sapphire/framework` <sup>[1](https://github.com/sapphiredev/plugins/blob/347cbdf0c792293573095ff76a2681188b936bb1/packages/logger/src/lib/Logger.ts#L1)</sup>.
- It does not depend on `@sapphire/time-utilities` <sup>[2](https://github.com/sapphiredev/plugins/blob/347cbdf0c792293573095ff76a2681188b936bb1/packages/logger/src/lib/LoggerTimestamp.ts#L1)</sup> for timestamp formatting, instead, it uses an opinionated format to reduce dependencies (and with it, CPU overhead as well as disk, and memory usage).
- It is ESM only.
- It is UTC only.
- Color configuration is more barebones.
- `Logger[level]` uses `util.format` for 2 or more arguments, aligning with Node's Console API. In contrast, the plugin inspects all arguments and joins them by a customizable delimiter.
- Defaults align with those desired by ArchId bots.
