### PR TITLE
refactor(shared-gateway-pieces): remove package

### DIFF
--- a/.npm-deprecaterc.yml
+++ b/.npm-deprecaterc.yml
@@ -5,6 +5,4 @@ package:
   - '@skyra/http-framework-i18n'
   - '@skyra/i18next-backend'
   - '@skyra/shared-http-pieces'
-  # TODO: Fix name when package.json is created
-  # - '@skyra/shared-gateway-pieces'
   - '@skyra/start-banner'

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@
 [![npm](https://img.shields.io/npm/v/@skyra/http-framework?color=crimson&logo=npm&style=flat-square&label=@skyra/http-framework)](https://www.npmjs.com/package/@skyra/http-framework)
 [![npm](https://img.shields.io/npm/v/@skyra/http-framework-i18n?color=crimson&logo=npm&style=flat-square&label=@skyra/http-framework-i18n)](https://www.npmjs.com/package/@skyra/http-framework-i18n)
 [![npm](https://img.shields.io/npm/v/@skyra/i18next-backend?color=crimson&logo=npm&style=flat-square&label=@skyra/i18next-backend)](https://www.npmjs.com/package/@skyra/i18next-backend)
-[![npm](https://img.shields.io/npm/v/@skyra/shared-gateway-pieces?color=crimson&logo=npm&style=flat-square&label=@skyra/shared-gateway-pieces)](https://www.npmjs.com/package/@skyra/shared-gateway-pieces)
 [![npm](https://img.shields.io/npm/v/@skyra/shared-http-pieces?color=crimson&logo=npm&style=flat-square&label=@skyra/shared-http-pieces)](https://www.npmjs.com/package/@skyra/shared-http-pieces)
 [![npm](https://img.shields.io/npm/v/@skyra/start-banner?color=crimson&logo=npm&style=flat-square&label=@skyra/start-banner)](https://www.npmjs.com/package/@skyra/start-banner)
 

--- a/packages/shared-gateway-pieces/README.md
+++ b/packages/shared-gateway-pieces/README.md
@@ -1,3 +1,0 @@
-# `@skyra/shared-gateway-pieces`
-
-The shared commands used for ArchId Network's gateway bots.

--- a/scripts/clean.mjs
+++ b/scripts/clean.mjs
@@ -10,7 +10,6 @@ const paths = [
 	new URL('http-framework/dist/', packagesDir),
 	new URL('http-framework-i18n/dist/', packagesDir),
 	new URL('i18next-backend/dist/', packagesDir),
-	new URL('shared-gateway-pieces/dist/', packagesDir),
 	new URL('shared-http-pieces/dist/', packagesDir),
 	new URL('start-banner/dist/', packagesDir),
 
@@ -19,7 +18,6 @@ const paths = [
 	new URL('http-framework/.turbo/', packagesDir),
 	new URL('http-framework-i18n/.turbo/', packagesDir),
 	new URL('i18next-backend/.turbo/', packagesDir),
-	new URL('shared-gateway-pieces/.turbo/', packagesDir),
 	new URL('shared-http-pieces/.turbo/', packagesDir),
 	new URL('start-banner/.turbo/', packagesDir)
 ];


### PR DESCRIPTION
Aelia was cancelled, and Skyra v7 is planned to use HFx and therefore no project would use Gateway Pieces, so it becabe extraneous.
