### PR TITLE
refactor: implement better context command support

### DIFF
--- a/packages/http-framework/src/lib/interactions/context-menu/decorators.ts
+++ b/packages/http-framework/src/lib/interactions/context-menu/decorators.ts
@@ -11,7 +11,7 @@ import { contextMenuCommandRegistry, type ContextMenuOptions } from './shared';
  * @example
  * ```typescript
  * export class UserCommand extends Command {
- * 	@RegisterUserCommand(createData())
+ * 	(at)RegisterUserCommand(createData())
  * 	public run(interaction: Command.UserInteraction, data: TransformedArguments.User) {
  * 		// ...
  * 	}
@@ -36,7 +36,7 @@ export function RegisterUserCommand(
  * @example
  * ```typescript
  * export class UserCommand extends Command {
- * 	@RegisterMessageCommand(createData())
+ * 	(at)RegisterMessageCommand(createData())
  * 	public run(interaction: Command.MessageInteraction, data: TransformedArguments.Message) {
  * 		// ...
  * 	}

--- a/packages/http-framework/src/lib/interactions/context-menu/decorators.ts
+++ b/packages/http-framework/src/lib/interactions/context-menu/decorators.ts
@@ -5,6 +5,20 @@ import { normalizeContextMenuCommand } from '../../utils/normalizeInput';
 import { link } from '../shared/link';
 import { contextMenuCommandRegistry, type ContextMenuOptions } from './shared';
 
+/**
+ * Registers a user command.
+ * @param command The command to register.
+ * @example
+ * ```typescript
+ * export class UserCommand extends Command {
+ * 	@RegisterUserCommand(createData())
+ * 	public run(interaction: Command.UserInteraction, data: TransformedArguments.User) {
+ * 		// ...
+ * 	}
+ * }
+ * ```
+ * @returns A method decorator function, does not override the method.
+ */
 export function RegisterUserCommand(
 	command: ContextMenuOptions | ContextMenuCommandBuilder | ((builder: ContextMenuCommandBuilder) => ContextMenuCommandBuilder)
 ) {
@@ -16,6 +30,20 @@ export function RegisterUserCommand(
 	};
 }
 
+/**
+ * Registers a message command.
+ * @param command The command to register.
+ * @example
+ * ```typescript
+ * export class UserCommand extends Command {
+ * 	@RegisterMessageCommand(createData())
+ * 	public run(interaction: Command.MessageInteraction, data: TransformedArguments.Message) {
+ * 		// ...
+ * 	}
+ * }
+ * ```
+ * @returns A method decorator function, does not override the method.
+ */
 export function RegisterMessageCommand(
 	command: ContextMenuOptions | ContextMenuCommandBuilder | ((builder: ContextMenuCommandBuilder) => ContextMenuCommandBuilder)
 ) {

--- a/packages/http-framework/src/lib/interactions/resolvers/InteractionOptions.ts
+++ b/packages/http-framework/src/lib/interactions/resolvers/InteractionOptions.ts
@@ -9,8 +9,11 @@ import {
 	type APIChatInputApplicationCommandInteractionDataResolved,
 	type APIInteractionDataResolvedChannel,
 	type APIInteractionDataResolvedGuildMember,
+	type APIMessage,
+	type APIMessageApplicationCommandInteractionData,
 	type APIRole,
-	type APIUser
+	type APIUser,
+	type APIUserApplicationCommandInteractionData
 } from 'discord-api-types/v10';
 
 export function transformInteraction<T extends NonNullObject>(
@@ -140,7 +143,19 @@ function transformMentionable(
 	return { id };
 }
 
+export function transformUserInteraction(data: APIUserApplicationCommandInteractionData): TransformedArguments.User {
+	return { user: data.resolved.users[data.target_id], member: data.resolved.members?.[data.target_id] ?? null };
+}
+
+export function transformMessageInteraction(data: APIMessageApplicationCommandInteractionData): TransformedArguments.Message {
+	return { message: data.resolved.messages[data.target_id] };
+}
+
 export namespace TransformedArguments {
+	export interface Message {
+		message: APIMessage;
+	}
+
 	export interface User {
 		user: APIUser;
 		member: APIInteractionDataResolvedGuildMember | null;

--- a/packages/http-framework/src/lib/structures/Command.ts
+++ b/packages/http-framework/src/lib/structures/Command.ts
@@ -283,6 +283,9 @@ export namespace Command {
 	export type Interaction = import('discord-api-types/v10').APIApplicationCommandInteraction;
 	export type InteractionData = Interaction['data'];
 
+	export type UserInteraction = import('discord-api-types/v10').APIUserApplicationCommandInteractionData;
+	export type MessageInteraction = import('discord-api-types/v10').APIMessageApplicationCommandInteractionData;
+
 	export type AutocompleteInteraction = import('discord-api-types/v10').APIApplicationCommandAutocompleteInteraction;
 
 	// Piece re-exports

--- a/packages/http-framework/src/lib/structures/CommandStore.ts
+++ b/packages/http-framework/src/lib/structures/CommandStore.ts
@@ -2,7 +2,7 @@ import { Store } from '@sapphire/pieces';
 import { ApplicationCommandType, type APIApplicationCommandAutocompleteInteraction } from 'discord-api-types/v10';
 import type { FastifyReply } from 'fastify';
 import { HttpCodes } from '../api/HttpCodes';
-import { transformAutocompleteInteraction, transformInteraction } from '../interactions';
+import { transformAutocompleteInteraction, transformInteraction, transformMessageInteraction, transformUserInteraction } from '../interactions';
 import { handleError, handleResponse, runner } from '../interactions/utils/util';
 import { Command } from './Command';
 
@@ -66,9 +66,9 @@ export class CommandStore extends Store<Command> {
 			case ApplicationCommandType.ChatInput:
 				return transformInteraction(data.resolved ?? {}, data.options ?? []);
 			case ApplicationCommandType.User:
-				return { [data.name]: { user: data.resolved.users[data.target_id], member: data.resolved.members?.[data.target_id] } };
+				return transformUserInteraction(data);
 			case ApplicationCommandType.Message:
-				return { [data.name]: { message: data.resolved.messages[data.target_id] } };
+				return transformMessageInteraction(data);
 			default:
 				throw new Error('Unknown ApplicationCommandType');
 		}


### PR DESCRIPTION
BREAKING CHANGE: User command options are not longer nested into `{ [interaction.name]: T }`
BREAKING CHANGE: Message command options are not longer nested into `{ [interaction.name]: T }`
