### PR TITLE
fix: add type in context menu register decorators

### DIFF
--- a/packages/http-framework/src/lib/interactions/context-menu/decorators.ts
+++ b/packages/http-framework/src/lib/interactions/context-menu/decorators.ts
@@ -22,11 +22,11 @@ import { contextMenuCommandRegistry, type ContextMenuOptions } from './shared';
 export function RegisterUserCommand(
 	command: ContextMenuOptions | ContextMenuCommandBuilder | ((builder: ContextMenuCommandBuilder) => ContextMenuCommandBuilder)
 ) {
-	const builtData = normalizeContextMenuCommand(command);
+	const builtData = normalizeContextMenuCommand(command, ApplicationCommandType.User);
 
 	return function decorate(target: Command, method: string) {
 		const commands = contextMenuCommandRegistry.ensure(target.constructor as typeof Command, () => []);
-		commands.push(link({ type: ApplicationCommandType.User, ...builtData }, method));
+		commands.push(link(builtData, method));
 	};
 }
 
@@ -47,10 +47,10 @@ export function RegisterUserCommand(
 export function RegisterMessageCommand(
 	command: ContextMenuOptions | ContextMenuCommandBuilder | ((builder: ContextMenuCommandBuilder) => ContextMenuCommandBuilder)
 ) {
-	const builtData = normalizeContextMenuCommand(command);
+	const builtData = normalizeContextMenuCommand(command, ApplicationCommandType.Message);
 
 	return function decorate(target: Command, method: string) {
 		const commands = contextMenuCommandRegistry.ensure(target.constructor as typeof Command, () => []);
-		commands.push(link({ type: ApplicationCommandType.Message, ...builtData }, method));
+		commands.push(link(builtData, method));
 	};
 }

--- a/packages/http-framework/src/lib/utils/normalizeInput.ts
+++ b/packages/http-framework/src/lib/utils/normalizeInput.ts
@@ -5,6 +5,7 @@
 
 import {
 	ContextMenuCommandBuilder,
+	ContextMenuCommandType,
 	SlashCommandBuilder,
 	SlashCommandOptionsOnlyBuilder,
 	SlashCommandSubcommandBuilder,
@@ -138,17 +139,18 @@ export function normalizeChatInputSubCommand(
 }
 
 export function normalizeContextMenuCommand(
-	command: ContextMenuOptions | ContextMenuCommandBuilder | ((builder: ContextMenuCommandBuilder) => ContextMenuCommandBuilder)
-): ContextMenuOptions {
+	command: ContextMenuOptions | ContextMenuCommandBuilder | ((builder: ContextMenuCommandBuilder) => ContextMenuCommandBuilder),
+	type: ContextMenuCommandType
+): RESTPostAPIContextMenuApplicationCommandsJSONBody {
 	if (isFunction(command)) {
-		const builder = new ContextMenuCommandBuilder();
+		const builder = new ContextMenuCommandBuilder().setType(type);
 		command(builder);
 		return builder.toJSON() as RESTPostAPIContextMenuApplicationCommandsJSONBody;
 	}
 
 	if (command instanceof ContextMenuCommandBuilder) {
-		return command.toJSON() as RESTPostAPIContextMenuApplicationCommandsJSONBody;
+		return command.setType(type).toJSON() as RESTPostAPIContextMenuApplicationCommandsJSONBody;
 	}
 
-	return command;
+	return { type, ...command };
 }


### PR DESCRIPTION
> **Note**: This is not https://github.com/skyra-project/archid-components/labels/semver%3Amajor because `normalizeContextMenuCommand` is not exported.