### PR TITLE
fix: do not override `options.interpolation` in `init`

### DIFF
--- a/packages/http-framework-i18n/src/lib/registry.ts
+++ b/packages/http-framework-i18n/src/lib/registry.ts
@@ -33,13 +33,13 @@ export async function init(options?: InitOptions) {
 		ns: [...loadedNamespaces],
 		preload: [...loadedLocales],
 		initImmediate: false,
+		ignoreJSONStructure: false,
+		...options,
 		interpolation: {
 			escapeValue: false,
 			skipOnVariables: false,
 			...options?.interpolation
-		},
-		ignoreJSONStructure: false,
-		...options
+		}
 	});
 
 	for (const { name, format } of loadedFormatters) {


### PR DESCRIPTION
Teryl overrides `interpolation` to add `defaultVariables`, but that accidentally removed the plugin's defaults.