### PR TITLE
refactor(hfx): add safe text body reader

### DIFF
--- a/packages/http-framework/src/lib/utils/constants.ts
+++ b/packages/http-framework/src/lib/utils/constants.ts
@@ -2,6 +2,10 @@ import { InteractionResponseType } from 'discord-api-types/v10';
 
 export const ErrorMessages = {
 	InternalError: JSON.stringify({ message: 'Received an internal error' }),
+	InvalidBodySize: JSON.stringify({ message: 'Request body exceeds maximum body size' }),
+	InvalidContentLengthInteger: JSON.stringify({ message: 'Content-Length is not an integer number' }),
+	InvalidContentLengthNegative: JSON.stringify({ message: 'Content-Length must not be zero or negative' }),
+	InvalidContentLengthTooBig: JSON.stringify({ message: "Content-Length is superior to the server's body size limit" }),
 	InvalidCustomId: JSON.stringify({ message: 'Could not parse the `custom_id` field' }),
 	InvalidSignature: JSON.stringify({ message: 'Received invalid signature' }),
 	MissingBodyData: JSON.stringify({ message: 'Missing body data' }),

--- a/packages/http-framework/src/lib/utils/streams.ts
+++ b/packages/http-framework/src/lib/utils/streams.ts
@@ -1,0 +1,44 @@
+import { container } from '@sapphire/pieces';
+import { err, ok } from '@sapphire/result';
+import { isNullishOrEmpty } from '@sapphire/utilities';
+import type { IncomingMessage } from 'node:http';
+import { TextDecoder } from 'node:util';
+import { ErrorMessages } from './constants';
+
+/**
+ * Safely reads the {@link IncomingMessage incoming message}'s body as a string.
+ * @param request The incoming message to get the data from.
+ * @returns The string, if it's within the body size limit.
+ */
+export async function getSafeTextBody(request: IncomingMessage) {
+	let limit = container.client.bodySizeLimit;
+
+	// Validate the Content-Length header:
+	if (!isNullishOrEmpty(request.headers['content-length'])) {
+		const parsed = Number(request.headers['content-length']);
+		if (!Number.isSafeInteger(parsed)) return err(ErrorMessages.InvalidContentLengthInteger);
+		if (parsed <= 0) return err(ErrorMessages.InvalidContentLengthNegative);
+		if (parsed > limit) return err(ErrorMessages.InvalidContentLengthTooBig);
+
+		// If it's a valid length, set the limit to it.
+		limit = parsed;
+	}
+
+	const decoder = new TextDecoder();
+
+	let output = '';
+	for await (const chunk of request) {
+		const part = typeof chunk === 'string' ? chunk : decoder.decode(chunk, { stream: true });
+		if (part.length + output.length > limit) return err(ErrorMessages.InvalidBodySize);
+
+		output += part;
+	}
+
+	// Flush the streaming TextDecoder so that any pending
+	// incomplete multibyte characters are handled.
+	const part = decoder.decode(undefined, { stream: false });
+	if (part.length + output.length > limit) return err(ErrorMessages.InvalidBodySize);
+
+	output += part;
+	return ok(output);
+}


### PR DESCRIPTION
This way, people can't take HTTP bots down by sending very large payloads.

The code is based on [`node:streams/consumers.json`](https://github.com/nodejs/node/blob/72aafbdba74d9d353f9b2d43df4072d4d061fb3f/lib/stream/consumers.js#L53-L70)