### PR TITLE
feat(safe-fetch): add package

### DIFF
--- a/packages/safe-fetch/.cliff-jumperrc.yml
+++ b/packages/safe-fetch/.cliff-jumperrc.yml
@@ -1,0 +1,3 @@
+name: safe-fetch
+org: skyra
+packagePath: packages/safe-fetch

--- a/packages/safe-fetch/CHANGELOG.md
+++ b/packages/safe-fetch/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.

--- a/packages/safe-fetch/README.md
+++ b/packages/safe-fetch/README.md
@@ -1,0 +1,18 @@
+# `@skyra/safe-fetch`
+
+A fetch wrapper on top of Rust's Result, powered by [`@sapphire/result`](https://www.npmjs.com/package/@sapphire/result).
+
+## Features
+
+-   Powered by the native `fetch` function
+-   CJS and ESM support
+
+## Usage
+
+```typescript
+import { safeFetch, json } from '@skyra/safe-fetch';
+
+const data = await json(safeFetch('https://api.example.org'));
+
+console.log(data);
+```

--- a/packages/safe-fetch/cliff.toml
+++ b/packages/safe-fetch/cliff.toml
@@ -1,0 +1,63 @@
+[changelog]
+header = """
+# Changelog
+
+All notable changes to this project will be documented in this file.\n
+"""
+body = """
+{% if version %}\
+    # [{{ version | trim_start_matches(pat="v") }}]\
+    {% if previous %}\
+        {% if previous.version %}\
+            (https://github.com/skyra-project/archid-components/compare/{{ previous.version }}...{{ version }})\
+        {% else %}\
+            (https://github.com/skyra-project/archid-components/tree/{{ version }})\
+        {% endif %}\
+    {% endif %} \
+    - ({{ timestamp | date(format="%Y-%m-%d") }})
+{% else %}\
+    # [unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ## {{ group | upper_first }}
+    {% for commit in commits %}
+		- {% if commit.scope %}\
+			**{{commit.scope}}:** \
+		  {% endif %}\
+            {{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/skyra-project/archid-components/commit/{{ commit.id }}))\
+		{% if commit.breaking %}\
+			{% for breakingChange in commit.footers %}\
+				\n{% raw %}  {% endraw %}- 💥 **{{ breakingChange.token }}{{ breakingChange.separator }}** {{ breakingChange.value }}\
+			{% endfor %}\
+		{% endif %}\
+    {% endfor %}
+{% endfor %}\n
+"""
+trim = true
+footer = ""
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+commit_parsers = [
+    { message = "^feat", group = "🚀 Features"},
+    { message = "^fix", group = "🐛 Bug Fixes"},
+    { message = "^docs", group = "📝 Documentation"},
+    { message = "^perf", group = "🏃 Performance"},
+    { message = "^refactor", group = "🏠 Refactor"},
+    { message = "^typings", group = "⌨️ Typings"},
+    { message = "^types", group = "⌨️ Typings"},
+    { message = ".*deprecated", body = ".*deprecated", group = "🚨 Deprecation"},
+    { message = "^revert", skip = true},
+    { message = "^style", group = "🪞 Styling"},
+    { message = "^test", group = "🧪 Testing"},
+    { message = "^chore", skip = true},
+    { message = "^ci", skip = true},
+    { message = "^build", skip = true},
+    { body = ".*security", group = "🛡️ Security"},
+]
+filter_commits = true
+tag_pattern = "@skyra/safe-fetch@[0-9]*"
+ignore_tags = ""
+topo_order = false
+sort_commits = "newest"

--- a/packages/safe-fetch/package.json
+++ b/packages/safe-fetch/package.json
@@ -1,0 +1,60 @@
+{
+	"name": "@skyra/safe-fetch",
+	"version": "1.0.0",
+	"description": "A fetch wrapper on top of Rust's Result",
+	"author": "@skyra",
+	"license": "Apache-2.0",
+	"main": "dist/index.js",
+	"module": "dist/index.mjs",
+	"types": "dist/index.d.ts",
+	"exports": {
+		"import": "./dist/index.mjs",
+		"types": "./dist/index.d.ts"
+	},
+	"sideEffects": false,
+	"scripts": {
+		"test": "eslint src --ext ts -c ../../package.json",
+		"build": "tsup",
+		"watch": "tsup --watch",
+		"lint": "eslint src --ext ts --fix -c ../../package.json",
+		"prepack": "yarn build",
+		"bump": "cliff-jumper",
+		"check-update": "cliff-jumper --dry-run"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/skyra-project/archid-components.git",
+		"directory": "packages/safe-fetch"
+	},
+	"files": [
+		"dist/**/*.mjs*",
+		"dist/**/*.d.ts"
+	],
+	"engines": {
+		"node": ">=18.0.0",
+		"npm": ">=8.0.0"
+	},
+	"keywords": [
+		"discord",
+		"api",
+		"http",
+		"skyra",
+		"typescript",
+		"ts",
+		"yarn"
+	],
+	"bugs": {
+		"url": "https://github.com/skyra-project/archid-components/issues"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"dependencies": {
+		"@sapphire/result": "^2.4.1"
+	},
+	"devDependencies": {
+		"@favware/cliff-jumper": "^1.8.7",
+		"tsup": "^6.2.3",
+		"typescript": "^4.8.2"
+	}
+}

--- a/packages/safe-fetch/src/index.ts
+++ b/packages/safe-fetch/src/index.ts
@@ -1,2 +1,2 @@
 export * from './lib/fetch';
-export * from './lib/errors/HttpError';
+export * from './lib/HttpError';

--- a/packages/safe-fetch/src/index.ts
+++ b/packages/safe-fetch/src/index.ts
@@ -1,0 +1,2 @@
+export * from './lib/fetch';
+export * from './lib/errors/HttpError';

--- a/packages/safe-fetch/src/lib/HttpError.ts
+++ b/packages/safe-fetch/src/lib/HttpError.ts
@@ -1,3 +1,6 @@
+// eslint-disable-next-line spaced-comment
+/// <reference lib="dom" />
+
 import { none, some, type Option } from '@sapphire/result';
 
 export class HttpError extends Error {
@@ -9,6 +12,10 @@ export class HttpError extends Error {
 		super('Received a non-OK HTTP response code');
 		this.response = response;
 		this.body = body;
+	}
+
+	public get url() {
+		return this.response.url;
 	}
 
 	public get code() {

--- a/packages/safe-fetch/src/lib/errors/HttpError.ts
+++ b/packages/safe-fetch/src/lib/errors/HttpError.ts
@@ -1,0 +1,24 @@
+import { none, some, type Option } from '@sapphire/result';
+
+export class HttpError extends Error {
+	public readonly response: Response;
+	public readonly body: string;
+	private json: Option<unknown> = none;
+
+	public constructor(response: Response, body: string) {
+		super('Received a non-OK HTTP response code');
+		this.response = response;
+		this.body = body;
+	}
+
+	public get code() {
+		return this.response.status;
+	}
+
+	public get jsonBody(): unknown {
+		return this.json.match({
+			some: (value) => value,
+			none: () => (this.json = some(JSON.parse(this.body)).unwrap())
+		});
+	}
+}

--- a/packages/safe-fetch/src/lib/fetch.ts
+++ b/packages/safe-fetch/src/lib/fetch.ts
@@ -1,6 +1,7 @@
 import { err, ok, type Result } from '@sapphire/result';
-import type { Awaitable, NonNullObject } from '@sapphire/utilities';
 import { HttpError } from './errors/HttpError';
+
+export type Awaitable<T> = PromiseLike<T> | T;
 
 export async function safeFetch(input: RequestInfo | URL, init?: RequestInit): Promise<FetchResult<Response>> {
 	try {
@@ -24,7 +25,7 @@ export async function Text(result: Awaitable<FetchResult<Response>>): Promise<Fe
 	return (await result).map((response) => response.text()).intoPromise();
 }
 
-export async function Json<T extends NonNullObject>(result: Awaitable<FetchResult<Response>>): Promise<FetchResult<T>> {
+export async function Json<T extends object>(result: Awaitable<FetchResult<Response>>): Promise<FetchResult<T>> {
 	return (await result).map((response) => response.json()).intoPromise();
 }
 

--- a/packages/safe-fetch/src/lib/fetch.ts
+++ b/packages/safe-fetch/src/lib/fetch.ts
@@ -1,5 +1,8 @@
+// eslint-disable-next-line spaced-comment
+/// <reference lib="dom" />
+
 import { err, ok, type Result } from '@sapphire/result';
-import { HttpError } from './errors/HttpError';
+import { HttpError } from './HttpError';
 
 export type Awaitable<T> = PromiseLike<T> | T;
 

--- a/packages/safe-fetch/src/lib/fetch.ts
+++ b/packages/safe-fetch/src/lib/fetch.ts
@@ -1,0 +1,49 @@
+import { err, ok, type Result } from '@sapphire/result';
+import type { Awaitable, NonNullObject } from '@sapphire/utilities';
+import { HttpError } from './errors/HttpError';
+
+export async function safeFetch(input: RequestInfo | URL, init?: RequestInit): Promise<FetchResult<Response>> {
+	try {
+		const response = await fetch(input, init);
+		if (response.ok) return ok(response);
+		return err(new HttpError(response, await response.text()));
+	} catch (error) {
+		return err(error as AbortError);
+	}
+}
+
+export async function safeTimedFetch(input: RequestInfo | URL, ms: number, init?: Omit<RequestInit, 'signal'>): Promise<FetchResult<Response>> {
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), ms);
+	const result = await safeFetch(input, { ...init, signal: controller.signal });
+	clearTimeout(timer);
+	return result;
+}
+
+export async function Text(result: Awaitable<FetchResult<Response>>): Promise<FetchResult<string>> {
+	return (await result).map((response) => response.text()).intoPromise();
+}
+
+export async function Json<T extends NonNullObject>(result: Awaitable<FetchResult<Response>>): Promise<FetchResult<T>> {
+	return (await result).map((response) => response.json()).intoPromise();
+}
+
+export async function Blob(result: Awaitable<FetchResult<Response>>): Promise<FetchResult<Blob>> {
+	return (await result).map((response) => response.blob()).intoPromise();
+}
+
+export async function ArrayBuffer(result: Awaitable<FetchResult<Response>>): Promise<FetchResult<ArrayBuffer>> {
+	return (await result).map((response) => response.arrayBuffer()).intoPromise();
+}
+
+export async function FormData(result: Awaitable<FetchResult<Response>>): Promise<FetchResult<FormData>> {
+	return (await result).map((response) => response.formData()).intoPromise();
+}
+
+export function isAbortError(error: Error): error is AbortError {
+	return error.name === 'AbortError';
+}
+
+export type AbortError = Error & { name: 'AbortError' };
+export type FetchError = HttpError | AbortError;
+export type FetchResult<T> = Result<T, FetchError>;

--- a/packages/safe-fetch/src/tsconfig.json
+++ b/packages/safe-fetch/src/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "../../../tsconfig.base.json",
+	"compilerOptions": {
+		"lib": ["DOM", "ESNext"],
+		"rootDir": "./",
+		"outDir": "../dist",
+		"tsBuildInfoFile": "../dist/.tsbuildinfo"
+	},
+	"include": ["."]
+}

--- a/packages/safe-fetch/tsconfig.eslint.json
+++ b/packages/safe-fetch/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"include": ["src", "tsup.config.ts"]
+}

--- a/packages/safe-fetch/tsup.config.ts
+++ b/packages/safe-fetch/tsup.config.ts
@@ -1,3 +1,3 @@
 import { createTsupConfig } from '../../scripts/tsup.config';
 
-export default createTsupConfig({ format: ['esm'] });
+export default createTsupConfig({ format: ['cjs', 'esm'] });

--- a/packages/safe-fetch/tsup.config.ts
+++ b/packages/safe-fetch/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../scripts/tsup.config';
+
+export default createTsupConfig({ format: ['esm'] });

--- a/yarn.lock
+++ b/yarn.lock
@@ -644,6 +644,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@skyra/safe-fetch@workspace:packages/safe-fetch":
+  version: 0.0.0-use.local
+  resolution: "@skyra/safe-fetch@workspace:packages/safe-fetch"
+  dependencies:
+    "@favware/cliff-jumper": ^1.8.7
+    "@sapphire/result": ^2.4.1
+    tsup: ^6.2.3
+    typescript: ^4.8.2
+  languageName: unknown
+  linkType: soft
+
 "@skyra/shared-http-pieces@workspace:packages/shared-http-pieces":
   version: 0.0.0-use.local
   resolution: "@skyra/shared-http-pieces@workspace:packages/shared-http-pieces"


### PR DESCRIPTION
Adds `@skyra/safe-fetch`, based on Teryl v1's code.

Requires Node.js v18+ and uses `@sapphire/result`, it's a heavy package compared to `@sapphire/fetch` due to the external dependency, and keeps logic simple by using FP patterns.
