### PR TITLE
feat!: added event hooks

### DIFF
--- a/packages/http-framework/package.json
+++ b/packages/http-framework/package.json
@@ -28,6 +28,7 @@
 		"@sapphire/pieces": "^3.5.2",
 		"@sapphire/result": "^2.6.0",
 		"@sapphire/utilities": "^3.11.0",
+		"@vladfrangu/async_event_emitter": "^2.1.2",
 		"discord-api-types": "^0.37.12"
 	},
 	"devDependencies": {

--- a/packages/http-framework/src/index.ts
+++ b/packages/http-framework/src/index.ts
@@ -15,6 +15,7 @@ export {
 } from '@sapphire/pieces';
 export * from './lib/api/HttpCodes';
 export * from './lib/Client';
+export * from './lib/ClientEvents';
 export * from './lib/components/IIdParser';
 export * from './lib/components/StringIdParser';
 export * from './lib/interactions';

--- a/packages/http-framework/src/lib/Client.ts
+++ b/packages/http-framework/src/lib/Client.ts
@@ -1,11 +1,12 @@
 import { REST, type RESTOptions } from '@discordjs/rest';
 import { container } from '@sapphire/pieces';
 import { isNullishOrEmpty } from '@sapphire/utilities';
+import { AsyncEventEmitter } from '@vladfrangu/async_event_emitter';
 import { InteractionType, type APIInteraction } from 'discord-api-types/v10';
-import { EventEmitter } from 'node:events';
 import { createServer, type IncomingMessage, type Server, type ServerOptions, type ServerResponse } from 'node:http';
 import type { ListenOptions as NetListenOptions } from 'node:net';
 import { HttpCodes } from './api/HttpCodes';
+import type { MappedClientEvents } from './ClientEvents';
 import type { IIdParser } from './components/IIdParser';
 import { StringIdParser } from './components/StringIdParser';
 import { CommandStore } from './structures/CommandStore';
@@ -19,13 +20,13 @@ container.stores.register(new CommandStore());
 container.stores.register(new InteractionHandlerStore());
 container.stores.register(new ListenerStore());
 
-export class Client extends EventEmitter {
+export class Client extends AsyncEventEmitter<MappedClientEvents> {
 	public server!: Server;
 	public readonly bodySizeLimit: number;
 	#discordPublicKey: string;
 
 	public constructor(options: ClientOptions = {}) {
-		super({ captureRejections: true });
+		super();
 		this.bodySizeLimit = options.bodySizeLimit ?? 1024 * 1024;
 
 		const discordPublicKey = options.discordPublicKey ?? process.env.DISCORD_PUBLIC_KEY;
@@ -185,9 +186,9 @@ export interface ListenOptions extends Omit<NetListenOptions, 'path' | 'readable
 }
 
 export namespace Client {
-	export type Options = import('./Client').ClientOptions;
-	export type PieceLoadOptions = import('./Client').LoadOptions;
-	export type ServerListenOptions = import('./Client').ListenOptions;
+	export type Options = ClientOptions;
+	export type PieceLoadOptions = LoadOptions;
+	export type ServerListenOptions = ListenOptions;
 }
 
 declare module '@sapphire/pieces' {

--- a/packages/http-framework/src/lib/ClientEvents.ts
+++ b/packages/http-framework/src/lib/ClientEvents.ts
@@ -1,0 +1,49 @@
+import type {
+	APIApplicationCommandAutocompleteInteraction,
+	APIApplicationCommandInteraction,
+	APIMessageComponentInteraction,
+	APIModalSubmitInteraction
+} from 'discord-api-types/v10';
+import type { ServerResponse } from 'node:http';
+import type { Command } from './structures/Command';
+import type { InteractionHandler } from './structures/InteractionHandler';
+
+export interface ClientEventCommandContext {
+	command: Command;
+	interaction: APIApplicationCommandInteraction;
+	response: ServerResponse;
+}
+
+export interface ClientEventAutocompleteContext {
+	command: Command;
+	interaction: APIApplicationCommandAutocompleteInteraction;
+	response: ServerResponse;
+}
+
+export interface ClientEventInteractionHandlerContext {
+	handler: InteractionHandler;
+	interaction: APIMessageComponentInteraction | APIModalSubmitInteraction;
+	response: ServerResponse;
+}
+
+export interface ClientEvents {
+	commandNameMissing: [interaction: APIApplicationCommandAutocompleteInteraction, response: ServerResponse];
+	commandNameUnknown: [interaction: APIApplicationCommandInteraction | APIApplicationCommandAutocompleteInteraction, response: ServerResponse];
+	commandMethodUnknown: [context: ClientEventCommandContext];
+	commandRun: [context: ClientEventCommandContext];
+	commandSuccess: [context: ClientEventCommandContext, value: unknown];
+	commandError: [error: unknown, context: ClientEventCommandContext];
+	commandFinish: [context: ClientEventCommandContext];
+	autocompleteRun: [context: ClientEventAutocompleteContext];
+	autocompleteSuccess: [context: ClientEventAutocompleteContext, value: unknown];
+	autocompleteError: [error: unknown, context: ClientEventAutocompleteContext];
+	autocompleteFinish: [context: ClientEventAutocompleteContext];
+	interactionHandlerNameInvalid: [interaction: APIMessageComponentInteraction | APIModalSubmitInteraction, response: ServerResponse];
+	interactionHandlerNameUnknown: [interaction: APIMessageComponentInteraction | APIModalSubmitInteraction, response: ServerResponse];
+	interactionHandlerRun: [context: ClientEventInteractionHandlerContext];
+	interactionHandlerSuccess: [context: ClientEventInteractionHandlerContext, value: unknown];
+	interactionHandlerError: [error: unknown, context: ClientEventInteractionHandlerContext];
+	interactionHandlerFinish: [context: ClientEventInteractionHandlerContext];
+}
+
+export type MappedClientEvents = { [K in keyof ClientEvents]: ClientEvents[K] };

--- a/packages/http-framework/src/lib/structures/InteractionHandlerStore.ts
+++ b/packages/http-framework/src/lib/structures/InteractionHandlerStore.ts
@@ -1,8 +1,9 @@
-import { Store } from '@sapphire/pieces';
+import { container, Store } from '@sapphire/pieces';
+import { Result } from '@sapphire/result';
 import type { APIMessageComponentInteraction, APIModalSubmitInteraction } from 'discord-api-types/v10';
 import type { ServerResponse } from 'node:http';
 import { HttpCodes } from '../..';
-import { makeInteraction } from '../interactions/utils/util';
+import { handleError, makeInteraction } from '../interactions/utils/util';
 import { ErrorMessages } from '../utils/constants';
 import { InteractionHandler } from './InteractionHandler';
 
@@ -15,19 +16,28 @@ export class InteractionHandlerStore extends Store<InteractionHandler> {
 		response: ServerResponse,
 		interaction: APIMessageComponentInteraction | APIModalSubmitInteraction
 	): Promise<ServerResponse> {
-		const parsed = this.container.idParser.run(interaction.data.custom_id);
+		const parsed = container.idParser.run(interaction.data.custom_id);
 		if (parsed === null) {
+			container.client.emit('interactionHandlerNameInvalid', interaction, response);
 			response.statusCode = HttpCodes.BadRequest;
 			return response.end(ErrorMessages.InvalidCustomId);
 		}
 
 		const handler = this.get(parsed.name);
 		if (!handler) {
+			container.client.emit('interactionHandlerNameUnknown', interaction, response);
 			response.statusCode = HttpCodes.NotImplemented;
 			return response.end(ErrorMessages.UnknownHandlerName);
 		}
 
-		await handler.run(makeInteraction(response, interaction), parsed.content);
+		const context = { handler, interaction, response };
+		container.client.emit('interactionHandlerRun', context);
+		const result = await Result.fromAsync(() => handler.run(makeInteraction(response, interaction), parsed.content));
+		result
+			.inspect((value) => container.client.emit('interactionHandlerSuccess', context, value))
+			.inspectErr((error) => (handleError(response, error), container.client.emit('interactionHandlerError', error, context)));
+
+		container.client.emit('interactionHandlerFinish', context);
 		return response;
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -613,6 +613,7 @@ __metadata:
     "@sapphire/result": ^2.6.0
     "@sapphire/utilities": ^3.11.0
     "@vitest/coverage-c8": ^0.24.3
+    "@vladfrangu/async_event_emitter": ^2.1.2
     discord-api-types: ^0.37.12
     tsup: ^6.3.0
     typescript: ^4.8.4
@@ -1246,6 +1247,13 @@ __metadata:
     c8: ^7.12.0
     vitest: 0.24.3
   checksum: 75f79fcf7cee7dbdfa4b8978aa80d791288e5975ed6ca723d8b4985ea744c3b022138075065058a9a679346910ae054e23f6ee922b779e8f6e7b88baf0a496fa
+  languageName: node
+  linkType: hard
+
+"@vladfrangu/async_event_emitter@npm:^2.1.2":
+  version: 2.1.2
+  resolution: "@vladfrangu/async_event_emitter@npm:2.1.2"
+  checksum: 31ffabd6b20c11db7ae9856daccb52371a00fb94d7ea6829286ab0bdb5f54bea8f987cd84c7b651d003a0761593ad56133956c0764be6492c840a1dd618b1ed7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
BREAKING CHANGE: `Client` now extends `@vladfrangu/async_event_emitter`'s AEE
