### PR TITLE
fix(i18next-backend): fixed types with i18next

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -45,6 +45,26 @@ jobs:
       - name: Build code
         run: yarn build
 
+  TypeChecking:
+    name: Type check code with tsc
+    runs-on: ubuntu-latest
+    if: false # TODO: Enable this once the currently broken type checking bugs are fixed
+    steps:
+      - name: Checkout Project
+        uses: actions/checkout@v3
+      - name: Add problem matchers
+        run: echo "::add-matcher::.github/problemMatchers/tsc.json"
+      - name: Use Node.js v16
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: yarn
+          registry-url: https://registry.npmjs.org/
+      - name: Install Dependencies
+        run: yarn --immutable
+      - name: Typecheck code
+        run: yarn typecheck
+
   UnitTesting:
     name: Unit Tests
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"format": "prettier --write \"packages/**/{src,tests,scripts}/**/*.{mjs,ts,js}\"",
 		"test": "vitest run",
 		"build": "turbo run build",
-		"update": "yarn upgrade-interactive",
+		"typecheck": "tsc -p tsconfig.eslint.json",
 		"postinstall": "husky install .github/husky",
 		"check-update": "turbo run check-update"
 	},

--- a/packages/i18next-backend/src/index.ts
+++ b/packages/i18next-backend/src/index.ts
@@ -3,12 +3,12 @@ import { readFileSync, type PathLike } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 
-export class Backend implements BackendModule<Backend.Options> {
+export class Backend<T = object> implements BackendModule<Backend.Options<T>> {
 	public readonly type = 'backend';
 	private paths!: readonly PathResolvable[];
 	private i18nextOptions!: InitOptions;
 
-	public init(_: Services, backendOptions: Backend.Options, i18nextOptions: InitOptions): void {
+	public init(_: Services, backendOptions: Backend.Options<T>, i18nextOptions: InitOptions): void {
 		this.paths = backendOptions.paths ?? [];
 		this.i18nextOptions = i18nextOptions;
 	}
@@ -79,15 +79,15 @@ export class Backend implements BackendModule<Backend.Options> {
 }
 
 export namespace Backend {
-	export interface Options {
+	export type Options<T = object> = T & {
 		paths: readonly PathResolvable[];
-	}
+	};
 }
 
 export type PathResolvable = string | URL | ((language: string, namespace: string) => PathLike);
 
 declare module 'i18next' {
-	interface InitOptions {
-		backend?: Backend.Options | undefined;
+	interface InitOptions<T = object> {
+		backend?: Backend.Options<T> | undefined;
 	}
 }

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,5 +1,10 @@
 {
 	"extends": "./tsconfig.base.json",
+	"compilerOptions": {
+		"noEmit": true,
+		"incremental": false,
+		"types": ["vitest/globals"]
+	},
 	"include": [
 		"packages/**/*.ts",
 		"packages/**/*.mjs",


### PR DESCRIPTION
i18next made their types stricter which caused a build issue with the latest version of the library. This PR fixes that issue.

Also added a (*currently disabled*) workflow job to type check the code. It is currently disabled because @skyra/http-framework has 17 type errors. Can you fix those please @kyranet?
