### PR TITLE
refactor: change error emit order

### DIFF
--- a/packages/http-framework/src/lib/structures/CommandStore.ts
+++ b/packages/http-framework/src/lib/structures/CommandStore.ts
@@ -46,7 +46,7 @@ export class CommandStore extends Store<Command> {
 		const result = await Result.fromAsync(() => this.runCommandMethod(command, method, makeInteraction(response, interaction)));
 		result
 			.inspect((value) => container.client.emit('commandSuccess', context, value))
-			.inspectErr((error) => (handleError(response, error), container.client.emit('commandError', error, context)));
+			.inspectErr((error) => (container.client.emit('commandError', error, context), handleError(response, error)));
 
 		container.client.emit('commandFinish', context);
 		return response;
@@ -77,7 +77,7 @@ export class CommandStore extends Store<Command> {
 		const result = await Result.fromAsync(() => command['autocompleteRun'](makeInteraction(response, interaction), options));
 		result
 			.inspect((value) => container.client.emit('autocompleteSuccess', context, value))
-			.inspectErr((error) => (handleError(response, error), container.client.emit('autocompleteError', error, context)));
+			.inspectErr((error) => (container.client.emit('autocompleteError', error, context), handleError(response, error)));
 
 		container.client.emit('autocompleteFinish', context);
 		return response;

--- a/packages/http-framework/src/lib/structures/InteractionHandlerStore.ts
+++ b/packages/http-framework/src/lib/structures/InteractionHandlerStore.ts
@@ -35,7 +35,7 @@ export class InteractionHandlerStore extends Store<InteractionHandler> {
 		const result = await Result.fromAsync(() => handler.run(makeInteraction(response, interaction), parsed.content));
 		result
 			.inspect((value) => container.client.emit('interactionHandlerSuccess', context, value))
-			.inspectErr((error) => (handleError(response, error), container.client.emit('interactionHandlerError', error, context)));
+			.inspectErr((error) => (container.client.emit('interactionHandlerError', error, context), handleError(response, error)));
 
 		container.client.emit('interactionHandlerFinish', context);
 		return response;


### PR DESCRIPTION
Necessary for bots with #226 to report exceptions with the labels, as Sentry deduplicates them with the first event's extras rather than combining them.
