### PR TITLE
fix: handle `resolved`'s keys being `undefined`

### DIFF
--- a/packages/http-framework/src/lib/interactions/structures/interactions/MessageComponentUserSelectInteraction.ts
+++ b/packages/http-framework/src/lib/interactions/structures/interactions/MessageComponentUserSelectInteraction.ts
@@ -41,7 +41,7 @@ export class MessageComponentUserSelectInteraction extends MessageComponentInter
 	public *values(): IterableIterator<MessageComponentUserSelectInteraction.Value> {
 		const { resolved } = this.data;
 		for (const id of this.ids) {
-			yield { user: resolved.users[id], member: resolved.members?.[id] ?? null };
+			yield { id, user: resolved.users[id], member: resolved.members?.[id] ?? null };
 		}
 	}
 


### PR DESCRIPTION
feat: added `id` to `TransformedArguments.User`
feat: added `TransformedArguments.PartialUser` for autocomplete
feat: added `TransformedArguments.PartialAttachment` for autocomplete
feat: added `TransformedArguments.PartialChannel` for autocomplete
feat: added `TransformedArguments.PartialRole` for autocomplete
feat: added `TransformedArguments.PartialAny` for autocomplete
