### PR TITLE
fix(twitch-helpers): remove duplicate function

### DIFF
--- a/packages/twitch-helpers/src/index.ts
+++ b/packages/twitch-helpers/src/index.ts
@@ -16,7 +16,7 @@ export type {
 	TwitchHelixUsersSearchResult,
 	TwitchOnlineEmbedData
 } from './lib/types.js';
-export { areClientCredentialsSet, areEventSubCredentialsSet, setVariables, type TwitchVariables } from './lib/variables.js';
+export { areTwitchClientCredentialsSet, areTwitchEventSubCredentialsSet, setVariables, type TwitchVariables } from './lib/variables.js';
 
 declare module '@skyra/env-utilities' {
 	interface Env {

--- a/packages/twitch-helpers/src/lib/twitch.ts
+++ b/packages/twitch-helpers/src/lib/twitch.ts
@@ -16,8 +16,7 @@ import type {
 	TwitchHelixUsersSearchResult
 } from './types.js';
 import {
-	getClientId,
-	getClientSecret,
+	areTwitchClientCredentialsSet,
 	getRequiredEventSubCallback,
 	getRequiredEventSubSecret,
 	getTwitchBearerTokenUrl,
@@ -26,15 +25,6 @@ import {
 } from './variables.js';
 
 let BearerToken: Option<TwitchHelixBearerToken> = none;
-
-/**
- * Checks if the Twitch credentials are set in the environment variables `TWITCH_CLIENT_ID` and `TWITCH_CLIENT_SECRET`
- *
- * @returns If the Twitch credentials are set
- */
-export function areTwitchCredentialsSet() {
-	return getClientId() !== null && getClientSecret() !== null;
-}
 
 /**
  * Fetches the user data for lists of User IDs and/or login names.
@@ -211,7 +201,7 @@ export async function getHeaders(): Promise<Headers> {
  * @returns The bearer token
  */
 export async function fetchBearer() {
-	if (!areTwitchCredentialsSet()) {
+	if (!areTwitchClientCredentialsSet()) {
 		throw new Error('Environment variable TWITCH_CLIENT_ID or TWITCH_CLIENT_SECRET was not set');
 	}
 

--- a/packages/twitch-helpers/src/lib/variables.ts
+++ b/packages/twitch-helpers/src/lib/variables.ts
@@ -47,7 +47,7 @@ export interface TwitchVariables {
  *
  * @returns If the Twitch client credentials are set
  */
-export function areClientCredentialsSet() {
+export function areTwitchClientCredentialsSet() {
 	return getClientId() !== null && getClientSecret() !== null;
 }
 
@@ -57,7 +57,7 @@ export function areClientCredentialsSet() {
  *
  * @returns If the Twitch EventSub credentials are set
  */
-export function areEventSubCredentialsSet() {
+export function areTwitchEventSubCredentialsSet() {
 	return getEventSubSecret() !== null && getEventSubCallback() !== null;
 }
 


### PR DESCRIPTION
These functions did the same but had different names. Removed one, kept the other. _technically_ a breaking change but we don't use either functions in Teryl and I doubt anyone else uses the lib anyway.