### PR TITLE
fix: possible race condition leading to 404s

### DIFF
--- a/packages/http-framework/src/lib/interactions/structures/interactions/base/BaseInteraction.ts
+++ b/packages/http-framework/src/lib/interactions/structures/interactions/base/BaseInteraction.ts
@@ -245,7 +245,12 @@ export abstract class BaseInteraction<T extends BaseInteractionType = BaseIntera
 		if (response.writableEnded) throw new Error('Cannot send response, the request has already been replied.');
 
 		response.statusCode = HttpCodes.OK;
-		return new Promise<void>((resolve) => response.end(JSON.stringify(data), resolve));
+		return new Promise<void>((resolve) => {
+			response.on('close', () => {
+				resolve();
+			});
+			response.end(JSON.stringify(data));
+		});
 	}
 }
 


### PR DESCRIPTION
This PR resolves a "unknown webhook" error message appearing due possible to a race condition. This error has received multiple complaints over at the [DDevs server](https://discord.com/channels/613425648685547541/1245841059515207821), though they are not using this library. The current speculation is that the error occurs due to a race condition, where the PATCH is processed by Discord before the initial interaction reply.

I have received hundreds of 404 errors over a year and so far have received none after implementing this fix in my own fork for a week. Only thing I noticed was that average ping times have gone up by around 200ms (servers in Germany), but at least the implementation is correct.

Relevent Node.js documentation: https://nodejs.org/api/http.html#responseenddata-encoding-callback

Event: 'close'
Indicates that the response is **completed**, or its underlying connection was terminated prematurely (before the response completion).

Event: 'finish'
Emitted when the response has been sent. More specifically, this event is emitted when the last segment of the response headers and body have been handed off to the operating system for transmission over the network. **It does not imply that the client has received anything yet.**

response.end([data[, encoding]][, callback])
If callback is specified, it will be called when the response stream is **finished.**