### PR TITLE
feat(env-utilities): add support for @skyra/env-utilities/setup

### DIFF
--- a/packages/env-utilities/package.json
+++ b/packages/env-utilities/package.json
@@ -9,16 +9,31 @@
 	"types": "dist/cjs/index.d.cts",
 	"type": "module",
 	"exports": {
-		"import": {
-			"types": "./dist/esm/index.d.ts",
-			"default": "./dist/esm/index.js"
+		".": {
+			"import": {
+				"types": "./dist/esm/index.d.ts",
+				"default": "./dist/esm/index.js"
+			},
+			"require": {
+				"types": "./dist/cjs/index.d.cts",
+				"default": "./dist/cjs/index.cjs"
+			}
 		},
-		"require": {
-			"types": "./dist/cjs/index.d.cts",
-			"default": "./dist/cjs/index.cjs"
+		"./setup": {
+			"import": {
+				"types": "./dist/esm/setup.d.ts",
+				"default": "./dist/esm/setup.js"
+			},
+			"require": {
+				"types": "./dist/cjs/setup.d.cts",
+				"default": "./dist/cjs/setup.cjs"
+			}
 		}
 	},
-	"sideEffects": false,
+	"sideEffects": [
+		"./dist/esm/setup.js",
+		"./dist/cjs/setup.cjs"
+	],
 	"scripts": {
 		"test": "vitest run",
 		"build": "tsup",

--- a/packages/env-utilities/src/setup.ts
+++ b/packages/env-utilities/src/setup.ts
@@ -1,0 +1,3 @@
+import { setup } from './index';
+
+setup();

--- a/packages/env-utilities/tsup.config.ts
+++ b/packages/env-utilities/tsup.config.ts
@@ -3,7 +3,8 @@ import type { Options } from 'tsup';
 import { createTsupConfig } from '../../scripts/tsup.config.js';
 
 const defaultOptions: Options = {
-	esbuildPlugins: [esbuildPluginVersionInjector()]
+	esbuildPlugins: [esbuildPluginVersionInjector()],
+	entry: ['src/index.ts', 'src/setup.ts']
 };
 
 export default createTsupConfig({


### PR DESCRIPTION
As you will know, dotenv has the option to execute its config function with the defaults, using the `dotenv/config` import. 

Therefore, I have added to ability to do the same with env-utilities.
```ts
import '@skyra/env-utilities/setup';
```

Both Skyra and Sapphire projects use `src/.env` so it wouldn't be very useful there. However, it would be great to have it for those (myself included) who prefer the default of it being in the root folder.

> [!NOTE]
> The only thing I haven't done is update the readme to include such. The reason is that I'm not that great with documentation and feel I would ruin the flow of how it's read.
> 
> One of those that I came up with was:
> > Alternatively, you can call setup using the dotenv defaults by using the following:
> > ```typescript
> > import '@skyra/env-utilities/setup';
> > ```
> But it doesn't seem to fit in with the rest of the readme. Any suggestions from either of you (Kyra, Favna) would be great!
