### PR TITLE
ci(publish): add contents permission

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,7 @@ jobs:
     if: github.repository_owner == 'skyra-project'
     permissions:
       id-token: write
+      contents: write
     steps:
       - name: Checkout Project
         uses: actions/checkout@v4


### PR DESCRIPTION
Addresses the recent permission problem that was introduced with my last PR. Long story short, adding the "id-token" permission reset all default permissions back to none.

This was first noticed with Sapphire utilities, where the following error was returned when attempting to create a release:
> Resource not accessible by integration - https://docs.github.com/rest/releases/releases#create-a-release