### PR TITLE
feat(hfx): allow replying to interactions with attachments

### DIFF
--- a/packages/http-framework/package.json
+++ b/packages/http-framework/package.json
@@ -34,7 +34,8 @@
 		"@sapphire/result": "^2.8.0",
 		"@sapphire/utilities": "^3.18.2",
 		"@vladfrangu/async_event_emitter": "^2.4.7",
-		"discord-api-types": "^0.38.8"
+		"discord-api-types": "^0.38.8",
+		"form-data-encoder": "^4.1.0"
 	},
 	"devDependencies": {
 		"@favware/cliff-jumper": "^6.0.0",

--- a/packages/http-framework/src/lib/interactions/structures/interactions/base/BaseInteraction.ts
+++ b/packages/http-framework/src/lib/interactions/structures/interactions/base/BaseInteraction.ts
@@ -13,7 +13,7 @@ import {
 	type RESTGetAPIGuildResult
 } from 'discord-api-types/v10';
 import type { ServerResponse } from 'node:http';
-import { Readable } from 'node:stream';
+import { Readable, pipeline } from 'node:stream';
 import { HttpCodes } from '../../../../api/HttpCodes.js';
 import type { DiscordResult } from '../../../utils/util-types.js';
 import { resultFromDiscord } from '../../../utils/util.js';
@@ -253,10 +253,19 @@ export abstract class BaseInteraction<T extends BaseInteractionType = BaseIntera
 			const form = new FormData();
 
 			for (const [index, file] of files.entries()) {
-				form.append(file.key ?? `files[${index}]`, file.data, file.name);
+				let buf;
+				if (Buffer.isBuffer(file.data)) {
+					buf = file.data;
+				} else if (file.data instanceof ArrayBuffer) {
+					buf = Buffer.from(file.data);
+				} else {
+					buf = Buffer.from(String(file.data), 'utf8');
+				}
+
+				form.append(file.key ?? `files[${index}]`, new Blob([buf], { type: file.contentType }), file.name);
 			}
 
-			form.append('payload_json', JSON.stringify(data));
+			form.append('payload_json', new Blob([JSON.stringify(data)], { type: 'application/json' }));
 
 			const encoder = new FormDataEncoder(form);
 			response.setHeader('Content-Type', encoder.headers['Content-Type']);
@@ -267,7 +276,10 @@ export abstract class BaseInteraction<T extends BaseInteractionType = BaseIntera
 
 			const readable = Readable.from(encoder);
 			return new Promise<void>((resolve, reject) => {
-				readable.pipe(response).on('close', resolve).on('error', reject);
+				response.on('close', resolve).on('error', reject);
+				pipeline(readable, response, (err) => {
+					if (err) return reject(err);
+				});
 			});
 		}
 

--- a/packages/http-framework/src/lib/interactions/structures/interactions/base/BaseInteraction.ts
+++ b/packages/http-framework/src/lib/interactions/structures/interactions/base/BaseInteraction.ts
@@ -1,6 +1,8 @@
+import type { RawFile } from '@discordjs/rest';
 import { container } from '@sapphire/pieces';
 import { Result, err } from '@sapphire/result';
 import { isNullish, isNullishOrEmpty, type NonNullObject } from '@sapphire/utilities';
+import { FormDataEncoder } from 'form-data-encoder';
 import {
 	Routes,
 	type APIChannel,
@@ -11,6 +13,7 @@ import {
 	type RESTGetAPIGuildResult
 } from 'discord-api-types/v10';
 import type { ServerResponse } from 'node:http';
+import { Readable } from 'node:stream';
 import { HttpCodes } from '../../../../api/HttpCodes.js';
 import type { DiscordResult } from '../../../utils/util-types.js';
 import { resultFromDiscord } from '../../../utils/util.js';
@@ -240,15 +243,36 @@ export abstract class BaseInteraction<T extends BaseInteractionType = BaseIntera
 		return resultFromDiscord(container.rest.get(Routes.guild(this.guildId)) as Promise<RESTGetAPIGuildResult>);
 	}
 
-	protected _sendReply(data: NonNullObject) {
+	protected _sendReply(data: NonNullObject, files?: RawFile[]) {
 		const response = this[Response];
 		if (response.writableEnded) throw new Error('Cannot send response, the request has already been replied.');
 
 		response.statusCode = HttpCodes.OK;
-		return new Promise<void>((resolve) => {
-			response.on('close', () => {
-				resolve();
+
+		if (files?.length) {
+			const form = new FormData();
+
+			for (const [index, file] of files.entries()) {
+				form.append(file.key ?? `files[${index}]`, file.data, file.name);
+			}
+
+			form.append('payload_json', JSON.stringify(data));
+
+			const encoder = new FormDataEncoder(form);
+			response.setHeader('Content-Type', encoder.headers['Content-Type']);
+
+			if (encoder.headers['Content-Length']) {
+				response.setHeader('Content-Length', encoder.headers['Content-Length']);
+			}
+
+			const readable = Readable.from(encoder);
+			return new Promise<void>((resolve, reject) => {
+				readable.pipe(response).on('close', resolve).on('error', reject);
 			});
+		}
+
+		return new Promise<void>((resolve, reject) => {
+			response.on('close', resolve).on('error', reject);
 			response.end(JSON.stringify(data));
 		});
 	}

--- a/packages/http-framework/src/lib/interactions/structures/interactions/base/CommandInteraction.ts
+++ b/packages/http-framework/src/lib/interactions/structures/interactions/base/CommandInteraction.ts
@@ -29,11 +29,12 @@ export type BaseCommandInteractionType =
 export class CommandInteraction<T extends BaseCommandInteractionType> extends BaseInteraction<T> {
 	/**
 	 * Responds to the interaction with a message.
-	 * @param data The data to be sent.
+	 * @param options The data to be sent.
 	 */
-	public async reply(data: MessageResponseOptions): Promise<PartialMessage<this>> {
+	public async reply(options: MessageResponseOptions): Promise<PartialMessage<this>> {
+		const { files, ...data } = options;
 		const body: MessageResponseData = { type: InteractionResponseType.ChannelMessageWithSource, data };
-		await this._sendReply(body);
+		await this._sendReply(body, files);
 		return new PartialMessage(this);
 	}
 

--- a/packages/http-framework/src/lib/interactions/structures/interactions/base/MessageComponentInteraction.ts
+++ b/packages/http-framework/src/lib/interactions/structures/interactions/base/MessageComponentInteraction.ts
@@ -44,22 +44,24 @@ export abstract class MessageComponentInteraction<T extends MessageComponentInte
 	}
 
 	/**
-	 * ACK an interaction and edit a response later. The user sees a loading state.
-	 * @param data The data to be sent, if any.
+	 * Edits the original interaction message.
+	 * @param options The data to be sent.
 	 */
-	public async update(data?: UpdateOptions): Promise<PartialMessage<this>> {
+	public async update(options: UpdateOptions): Promise<PartialMessage<this>> {
+		const { files, ...data } = options;
 		const body: UpdateData = { type: InteractionResponseType.UpdateMessage, data };
-		await this._sendReply(body);
+		await this._sendReply(body, files);
 		return new PartialMessage(this);
 	}
 
 	/**
 	 * Responds to the interaction with a message.
-	 * @param data The data to be sent.
+	 * @param options The data to be sent.
 	 */
-	public async reply(data: MessageResponseOptions): Promise<PartialMessage<this>> {
+	public async reply(options: MessageResponseOptions): Promise<PartialMessage<this>> {
+		const { files, ...data } = options;
 		const body: MessageResponseData = { type: InteractionResponseType.ChannelMessageWithSource, data };
-		await this._sendReply(body);
+		await this._sendReply(body, files);
 		return new PartialMessage(this);
 	}
 

--- a/packages/http-framework/src/lib/interactions/structures/interactions/base/common.ts
+++ b/packages/http-framework/src/lib/interactions/structures/interactions/base/common.ts
@@ -13,7 +13,7 @@ export type AutocompleteResponseData = APIApplicationCommandAutocompleteResponse
 export type AutocompleteResponseOptions = AutocompleteResponseData['data'];
 
 export type MessageResponseData = APIInteractionResponseChannelMessageWithSource;
-export type MessageResponseOptions = MessageResponseData['data'];
+export type MessageResponseOptions = AddFiles<MessageResponseData['data']>;
 export type DeferResponseData = APIInteractionResponseDeferredChannelMessageWithSource;
 export type DeferResponseOptions = DeferResponseData['data'];
 export type ModalResponseData = APIModalInteractionResponse;
@@ -22,4 +22,4 @@ export type FollowupOptions = AddFiles<RESTPostAPIInteractionFollowupJSONBody>;
 
 export type DeferUpdateResult = APIInteractionResponseDeferredMessageUpdate;
 export type UpdateData = APIInteractionResponseUpdateMessage;
-export type UpdateOptions = UpdateData['data'];
+export type UpdateOptions = AddFiles<UpdateData['data']>;

--- a/packages/http-framework/tests/lib/interactions/structures/base/CommandInteraction.test.ts
+++ b/packages/http-framework/tests/lib/interactions/structures/base/CommandInteraction.test.ts
@@ -41,10 +41,21 @@ describe('CommandInteraction', () => {
 			const response = makeResponse();
 			const interaction = new ChatInputCommandInteraction(response, ChatInputApplicationCommandInteractionData);
 
+			const spy = vi.spyOn(response, 'write');
+
 			await interaction.reply({
 				content: 'Hello with multiple files',
 				files: MultipleFilesData
 			});
+
+			const calls = spy.mock.calls.flatMap((calls) => calls[0]);
+			const buffers = calls.map((u: Uint8Array) => Buffer.from(u));
+			const joined = Buffer.concat(buffers);
+
+			expect(joined.indexOf(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))).toBeGreaterThan(0);
+			expect(joined.includes(Buffer.from('file1.png'))).toBe(true);
+			expect(joined.includes(Buffer.from('image/png'))).toBe(true);
+			expect(joined.includes(Buffer.from('file content'))).toBe(true);
 
 			expect(response.getHeader('Content-Type')).toContain('multipart/form-data');
 			expect(response.writableEnded).toBe(true);

--- a/packages/http-framework/tests/lib/interactions/structures/base/CommandInteraction.test.ts
+++ b/packages/http-framework/tests/lib/interactions/structures/base/CommandInteraction.test.ts
@@ -6,7 +6,7 @@ import {
 	type MessageResponseOptions,
 	type ModalResponseOptions
 } from '../../../../../src/index.js';
-import { ChatInputApplicationCommandInteractionData, makeResponse } from '../../../../shared.js';
+import { ChatInputApplicationCommandInteractionData, makeResponse, MultipleFilesData } from '../../../../shared.js';
 
 // NOTE: The reason why we use `spy.mock.calls[0][0]` is because `toHaveBeenCalledWith` would need to match
 // a function, which is impossible to do in tests, so we hack into the mock's calls and match the first
@@ -35,6 +35,33 @@ describe('CommandInteraction', () => {
 
 			await instance.reply(data);
 			await expect(instance.reply(data)).rejects.toThrowError(AlreadyRepliedMessage);
+		});
+
+		test('GIVEN reply with files THEN sends multipart/form-data', async () => {
+			const response = makeResponse();
+			const interaction = new ChatInputCommandInteraction(response, ChatInputApplicationCommandInteractionData);
+
+			await interaction.reply({
+				content: 'Hello with multiple files',
+				files: MultipleFilesData
+			});
+
+			expect(response.getHeader('Content-Type')).toContain('multipart/form-data');
+			expect(response.writableEnded).toBe(true);
+		});
+
+		test('GIVEN reply with empty files array THEN sends JSON', async () => {
+			const response = makeResponse();
+			const interaction = new ChatInputCommandInteraction(response, ChatInputApplicationCommandInteractionData);
+
+			await interaction.reply({
+				content: 'Hello with empty files',
+				files: []
+			});
+
+			// Content-Type application/json is not mocked as it is set early in the response lifecycle
+			expect(response.getHeader('Content-Type')).toBeUndefined();
+			expect(response.writableEnded).toBe(true);
 		});
 	});
 

--- a/packages/http-framework/tests/shared.ts
+++ b/packages/http-framework/tests/shared.ts
@@ -1,3 +1,4 @@
+import type { RawFile } from '@discordjs/rest';
 import {
 	ApplicationCommandType,
 	ComponentType,
@@ -188,8 +189,41 @@ export const ModalSubmitInteractionData: APIModalSubmitInteraction = {
 	message: MessageData
 };
 
+export const MultipleFilesData: RawFile[] = [
+	{
+		data: 'file content',
+		name: 'test.txt',
+		key: 'files[0]'
+	},
+	{
+		data: Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+		name: 'file1.png',
+		key: 'files[1]'
+	},
+	{
+		data: 12345678,
+		name: 'file2.txt',
+		key: 'files[2]'
+	},
+	{
+		data: true,
+		name: 'file3.txt',
+		key: 'files[3]'
+	}
+];
+
 export function makeResponse() {
-	const response = new Writable();
+	const response = new Writable() as ServerResponse;
+
+	// Mock header functions
+	const headers: Record<string, string> = {};
+	response.setHeader = (name: string, value: string) => {
+		headers[name] = value;
+		return response;
+	};
+	response.getHeader = (name: string) => {
+		return headers[name];
+	};
 	response._write = (_chunk: any, _encoding: BufferEncoding, callback: (error?: Error | null) => void) => callback();
-	return response as ServerResponse;
+	return response;
 }

--- a/packages/http-framework/tests/shared.ts
+++ b/packages/http-framework/tests/shared.ts
@@ -193,15 +193,17 @@ export const MultipleFilesData: RawFile[] = [
 	{
 		data: 'file content',
 		name: 'test.txt',
-		key: 'files[0]'
+		key: 'files[0]',
+		contentType: 'text/plain'
 	},
 	{
 		data: Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
 		name: 'file1.png',
-		key: 'files[1]'
+		key: 'files[1]',
+		contentType: 'image/png'
 	},
 	{
-		data: 12345678,
+		data: 0xdeadbeef,
 		name: 'file2.txt',
 		key: 'files[2]'
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -1718,6 +1718,7 @@ __metadata:
     "@vitest/coverage-v8": "npm:^4.0.8"
     "@vladfrangu/async_event_emitter": "npm:^2.4.7"
     discord-api-types: "npm:^0.38.8"
+    form-data-encoder: "npm:^4.1.0"
     tsup: "npm:^8.5.0"
     typescript: "npm:~5.8.3"
     vitest: "npm:^4.0.8"
@@ -3803,6 +3804,13 @@ __metadata:
     cross-spawn: "npm:^7.0.6"
     signal-exit: "npm:^4.0.1"
   checksum: 10/427b33f997a98073c0424e5c07169264a62cda806d8d2ded159b5b903fdfc8f0a1457e06b5fc35506497acb3f1e353f025edee796300209ac6231e80edece835
+  languageName: node
+  linkType: hard
+
+"form-data-encoder@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "form-data-encoder@npm:4.1.0"
+  checksum: 10/a3f5a2f50d8832b9d39a36acce04ac388290982a944d0a8aac9735a50d1fb3276b1e40e3a9bce9eeb8bb17f6ab6f91a5ec1d65c6ee2603d83f1b9caad6b7ded2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#147 removed attachment uploading because Fastify did not support it. Now that the library uses node:http, we can support it again.

This PR allows `interaction.reply` and `interaction.update` to accept an optional files parameter.